### PR TITLE
Add scenario orchestration endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ Open:
 - **api/** OpenAPI stub
 - **docker-compose.yml** Postgres + Adminer (http://localhost:8080)
 
+## Real-world automation playbooks
+
+Use the new `/api/scenarios/*` endpoints to emulate end-to-end pipelines for common SDOH touchpoints:
+
+- `POST /api/scenarios/care-coordination-call` – ingest call transcripts, detect Z-codes, and emit email-ready action plans for case managers.
+- `POST /api/scenarios/sms-screening` – triage inbound SMS replies, auto-respond, and notify coordinators.
+- `POST /api/scenarios/ehr-intake` – transform intake forms into FHIR-like bundles with recommended Z-codes.
+- `POST /api/scenarios/monitoring` – prioritize hybrid voice/SMS wellness checks for senior populations.
+- `POST /api/scenarios/care-team-alert` – raise alerts and link out to dashboards when multiple high-risk needs surface.
+- `POST /api/scenarios/population-health` – roll up detection results for analytics, prevalence, and revenue insights.
+- `POST /api/scenarios/post-discharge` – capture barriers right after discharge and trigger rapid follow-up.
+
 ## Next steps (optional)
 - Wire real auth + tenant resolution (JWT → `x-tenant-id` header).
 - Flesh out referrals/outcomes persistence and PDF timeline fetching from DB.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -21,3 +21,31 @@ paths:
     post:
       summary: Generate evidence PDF
       responses: { '200': { description: ok } }
+  /api/scenarios/care-coordination-call:
+    post:
+      summary: Orchestrate care coordination call workflow
+      responses: { '200': { description: ok } }
+  /api/scenarios/sms-screening:
+    post:
+      summary: Handle SMS screening conversation
+      responses: { '200': { description: ok } }
+  /api/scenarios/ehr-intake:
+    post:
+      summary: Process intake form for EHR integration
+      responses: { '200': { description: ok } }
+  /api/scenarios/monitoring:
+    post:
+      summary: Evaluate hybrid voice/SMS monitoring responses
+      responses: { '200': { description: ok } }
+  /api/scenarios/care-team-alert:
+    post:
+      summary: Generate care team alert and email notification
+      responses: { '200': { description: ok } }
+  /api/scenarios/population-health:
+    post:
+      summary: Aggregate population health metrics from detections
+      responses: { '200': { description: ok } }
+  /api/scenarios/post-discharge:
+    post:
+      summary: Process post-discharge follow-up response
+      responses: { '200': { description: ok } }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,6 +4,7 @@ import screenings from './routes/screenings';
 import zcodes from './routes/zcodes';
 import evidence from './routes/evidence';
 import ai from './routes/ai';
+import scenarios from './routes/scenarios';
 
 const app = express();
 app.use(cors());
@@ -15,5 +16,16 @@ app.use('/api/screenings', screenings);
 app.use('/api/zcodes', zcodes);
 app.use('/api/evidence', evidence);
 app.use('/api/ai', ai);
+app.use('/api/scenarios', scenarios);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  const status = typeof err?.status === 'number' ? err.status : 400;
+  const message = err instanceof Error ? err.message : 'Unknown error';
+  if (err instanceof Error && 'issues' in err) {
+    console.error('[app] request validation error', err);
+  }
+  res.status(status).json({ error: message });
+});
 
 export default app;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import zcodes from './routes/zcodes';
 import evidence from './routes/evidence';
 import ai from './routes/ai';
 import scenarios from './routes/scenarios';
+import detections from './routes/detections';
 
 const app = express();
 app.use(cors());
@@ -17,6 +18,7 @@ app.use('/api/zcodes', zcodes);
 app.use('/api/evidence', evidence);
 app.use('/api/ai', ai);
 app.use('/api/scenarios', scenarios);
+app.use('/api/ai/detections', detections);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -92,3 +92,16 @@ export const auditEvents = pgTable('audit_events', {
   details: jsonb('details'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 });
+
+export const aiDetections = pgTable('ai_detections', {
+  id: uuid('id').primaryKey(),
+  scenarioId: text('scenario_id').notNull(),
+  scenarioName: text('scenario_name').notNull(),
+  memberId: text('member_id').notNull(),
+  memberName: text('member_name'),
+  issues: jsonb('issues').notNull(),
+  narrative: text('narrative'),
+  revenue: jsonb('revenue'),
+  compliance: jsonb('compliance'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -1,11 +1,143 @@
 import { Router } from 'express';
+import { z } from 'zod';
 import { detectConversation } from '../services/sdohEngine';
+import { sendEmail } from '../services/notifications';
 
 const r = Router();
 
 r.post('/detect', async (req, res, next) => {
   try {
     const result = await detectConversation(req.body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+const sendSummarySchema = z.object({
+  to: z.array(z.string().email()).nonempty(),
+  scenarioName: z.string(),
+  scenarioId: z.string().optional(),
+  memberId: z.string(),
+  memberName: z.string().optional(),
+  detection: z.object({
+    issues: z
+      .array(
+        z.object({
+          code: z.string(),
+          label: z.string(),
+          severity: z.string(),
+          urgency: z.string(),
+          confidence: z.number(),
+        })
+      )
+      .default([]),
+    documentation: z
+      .object({ narrative: z.string().optional() })
+      .passthrough()
+      .optional(),
+    revenue: z
+      .object({ potentialRevenue: z.number().optional() })
+      .passthrough()
+      .optional(),
+    compliance: z
+      .object({
+        completionRate: z.number().optional(),
+        alerts: z
+          .array(
+            z.object({
+              message: z.string(),
+              severity: z.enum(['info', 'warning', 'critical']).optional(),
+            })
+          )
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+  }),
+});
+
+function buildIssuesTable(
+  issues: z.infer<typeof sendSummarySchema>['detection']['issues']
+): { text: string; html: string } {
+  if (!issues.length) {
+    const message = 'No active SDOH risks detected.';
+    return { text: message, html: `<p><strong>${message}</strong></p>` };
+  }
+
+  const text = issues
+    .map(
+      (issue) =>
+        `${issue.label} (${issue.code}) — severity ${issue.severity}, urgency ${issue.urgency}, confidence ${Math.round(issue.confidence * 100) / 100}`
+    )
+    .join('\n');
+
+  const rows = issues
+    .map(
+      (issue) =>
+        `<tr><td>${issue.code}</td><td>${issue.label}</td><td>${issue.severity}</td><td>${issue.urgency}</td><td>${issue.confidence.toFixed(
+          2
+        )}</td></tr>`
+    )
+    .join('');
+
+  const html = `
+    <table border="1" cellpadding="6" cellspacing="0">
+      <thead>
+        <tr>
+          <th>Code</th>
+          <th>Description</th>
+          <th>Severity</th>
+          <th>Urgency</th>
+          <th>Confidence</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+
+  return { text, html };
+}
+
+r.post('/send-summary', async (req, res, next) => {
+  try {
+    const body = sendSummarySchema.parse(req.body);
+    const { text, html } = buildIssuesTable(body.detection.issues);
+    const narrative = body.detection.documentation?.narrative;
+    const revenue = body.detection.revenue?.potentialRevenue;
+    const completionRate = body.detection.compliance?.completionRate;
+    const alerts = body.detection.compliance?.alerts ?? [];
+
+    const narrativeText = narrative ? `Narrative Summary:\n${narrative}\n\n` : '';
+    const revenueText = typeof revenue === 'number' ? `Potential Revenue Impact: $${revenue.toLocaleString()}\n` : '';
+    const complianceText = typeof completionRate === 'number' ? `Compliance Completion Rate: ${Math.round(completionRate * 100) / 100}%\n` : '';
+    const alertsText = alerts.length
+      ? `Alerts:\n${alerts.map((alert) => `• ${alert.message}`).join('\n')}\n\n`
+      : '';
+
+    const emailText = `${narrativeText}${revenueText}${complianceText}${alertsText}${text}`.trim();
+    const emailHtml = `
+      <div>
+        ${narrative ? `<p><strong>Narrative Summary</strong><br/>${narrative}</p>` : ''}
+        ${typeof revenue === 'number' ? `<p><strong>Potential Revenue Impact:</strong> $${revenue.toLocaleString()}</p>` : ''}
+        ${typeof completionRate === 'number' ? `<p><strong>Compliance Completion Rate:</strong> ${completionRate}%</p>` : ''}
+        ${alerts.length ? `<ul>${alerts.map((alert) => `<li>${alert.message}</li>`).join('')}</ul>` : ''}
+        ${html}
+      </div>
+    `;
+
+    const result = await sendEmail({
+      to: body.to,
+      subject: `SDOH Summary • ${body.scenarioName} • ${body.memberName ?? body.memberId}`,
+      text: emailText,
+      html: emailHtml,
+      categories: ['sdoh-summary', body.scenarioId ?? 'sdoh-scenarios'],
+      customArgs: {
+        scenario: body.scenarioName,
+        memberId: body.memberId,
+      },
+    });
+
     res.json(result);
   } catch (error) {
     next(error);

--- a/server/src/routes/detections.ts
+++ b/server/src/routes/detections.ts
@@ -1,0 +1,98 @@
+import { Router } from 'express';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { aiDetections } from '../db/schema';
+import { db } from '../util/db';
+import { desc } from 'drizzle-orm';
+
+const r = Router();
+
+const alertSchema = z.object({
+  message: z.string(),
+  severity: z.enum(['info', 'warning', 'critical']).optional(),
+});
+
+const issueSchema = z.object({
+  code: z.string(),
+  label: z.string(),
+  severity: z.string(),
+  urgency: z.string(),
+  confidence: z.number(),
+  status: z.string().optional(),
+  rationale: z.string().optional(),
+});
+
+const detectionPayloadSchema = z.object({
+  scenarioId: z.string(),
+  scenarioName: z.string(),
+  memberId: z.string(),
+  memberName: z.string().optional(),
+  detection: z.object({
+    issues: z.array(issueSchema).default([]),
+    documentation: z
+      .object({ narrative: z.string().optional() })
+      .passthrough()
+      .optional(),
+    revenue: z
+      .object({ potentialRevenue: z.number().optional() })
+      .passthrough()
+      .optional(),
+    compliance: z
+      .object({
+        completionRate: z.number().optional(),
+        alerts: z.array(alertSchema).optional(),
+      })
+      .passthrough()
+      .optional(),
+  }),
+});
+
+r.post('/', async (req, res, next) => {
+  try {
+    const body = detectionPayloadSchema.parse(req.body);
+    const id = randomUUID();
+    await db.insert(aiDetections).values({
+      id,
+      scenarioId: body.scenarioId,
+      scenarioName: body.scenarioName,
+      memberId: body.memberId,
+      memberName: body.memberName,
+      issues: body.detection.issues as unknown as any,
+      narrative: body.detection.documentation?.narrative,
+      revenue: body.detection.revenue as unknown as any,
+      compliance: body.detection.compliance as unknown as any,
+    });
+    res.json({ id });
+  } catch (error) {
+    next(error);
+  }
+});
+
+r.get('/', async (req, res, next) => {
+  try {
+    const limit = Math.min(50, Math.max(1, Number(req.query.limit) || 10));
+    const rows = await db
+      .select()
+      .from(aiDetections)
+      .orderBy(desc(aiDetections.createdAt))
+      .limit(limit);
+    res.json({
+      detections: rows.map((row) => ({
+        id: row.id,
+        scenarioId: row.scenarioId,
+        scenarioName: row.scenarioName,
+        memberId: row.memberId,
+        memberName: row.memberName,
+        issues: (row.issues as unknown as z.infer<typeof issueSchema>[]) ?? [],
+        narrative: row.narrative,
+        revenue: row.revenue as Record<string, unknown> | null,
+        compliance: row.compliance as Record<string, unknown> | null,
+        createdAt: row.createdAt?.toISOString?.() ?? new Date().toISOString(),
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default r;

--- a/server/src/routes/scenarios.ts
+++ b/server/src/routes/scenarios.ts
@@ -1,0 +1,188 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import {
+  processCareCoordinationCall,
+  processSmsScreening,
+  processEhrIntake,
+  processMonitoringCheckIn,
+  processCareTeamAlert,
+  processPopulationHealth,
+  processPostDischarge,
+} from '../services/scenarioPipeline';
+
+const r = Router();
+
+const messageSchema = z.object({
+  speaker: z.string(),
+  text: z.string(),
+  language: z.string().optional(),
+  timestamp: z.string().optional(),
+});
+
+r.post('/care-coordination-call', async (req, res, next) => {
+  try {
+    const body = z
+      .object({
+        memberId: z.string(),
+        caseManagerEmail: z.string().email(),
+        workerName: z.string().optional(),
+        workerEmail: z.string().email().optional(),
+        encounterId: z.string().optional(),
+        context: z
+          .object({
+            encounterId: z.string().optional(),
+            careTeam: z.array(z.string()).optional(),
+            requiredScreenings: z.number().optional(),
+            completedScreenings: z.number().optional(),
+            monthlyGoal: z.number().optional(),
+          })
+          .optional(),
+        transcript: z.array(messageSchema),
+      })
+      .parse(req.body);
+
+    const result = await processCareCoordinationCall(body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+r.post('/sms-screening', async (req, res, next) => {
+  try {
+    const body = z
+      .object({
+        memberId: z.string(),
+        outreachPrompt: z.string(),
+        memberReply: z.string(),
+        memberPhone: z.string(),
+        coordinatorEmail: z.string().email(),
+        fromNumber: z.string().optional(),
+      })
+      .parse(req.body);
+
+    const result = await processSmsScreening(body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+r.post('/ehr-intake', async (req, res, next) => {
+  try {
+    const body = z
+      .object({
+        memberId: z.string(),
+        encounterId: z.string().optional(),
+        responses: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).default({}),
+        additionalNote: z.string().optional(),
+        destinationEmail: z.string().email(),
+      })
+      .parse(req.body);
+
+    const result = await processEhrIntake(body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+r.post('/monitoring', async (req, res, next) => {
+  try {
+    const body = z
+      .object({
+        memberId: z.string(),
+        checkInId: z.string().optional(),
+        responses: z
+          .array(
+            z.object({
+              prompt: z.string(),
+              reply: z.string(),
+              channel: z.enum(['voice', 'sms']),
+              timestamp: z.string().optional(),
+            })
+          )
+          .default([]),
+        notifyEmails: z.array(z.string().email()).nonempty(),
+      })
+      .parse(req.body);
+
+    const result = await processMonitoringCheckIn(body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+r.post('/care-team-alert', async (req, res, next) => {
+  try {
+    const body = z
+      .object({
+        memberId: z.string(),
+        transcript: z.array(messageSchema),
+        dashboardUrl: z.string().url().optional(),
+        notifyEmails: z.array(z.string().email()).nonempty(),
+      })
+      .parse(req.body);
+
+    const result = await processCareTeamAlert(body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+r.post('/population-health', async (req, res, next) => {
+  try {
+    const body = z
+      .object({
+        tenantId: z.string().optional(),
+        cohort: z
+          .array(
+            z.object({
+              memberId: z.string(),
+              transcript: z.array(messageSchema),
+              context: z
+                .object({
+                  encounterId: z.string().optional(),
+                  careTeam: z.array(z.string()).optional(),
+                  requiredScreenings: z.number().optional(),
+                  completedScreenings: z.number().optional(),
+                  monthlyGoal: z.number().optional(),
+                })
+                .optional(),
+            })
+          )
+          .nonempty(),
+      })
+      .parse(req.body);
+
+    const result = await processPopulationHealth(body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+r.post('/post-discharge', async (req, res, next) => {
+  try {
+    const body = z
+      .object({
+        memberId: z.string(),
+        memberPhone: z.string(),
+        careTeamEmail: z.string().email(),
+        encounterId: z.string().optional(),
+        dischargeSummary: z.string().optional(),
+        memberReply: z.string(),
+        fromNumber: z.string().optional(),
+      })
+      .parse(req.body);
+
+    const result = await processPostDischarge(body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default r;

--- a/server/src/services/notifications.ts
+++ b/server/src/services/notifications.ts
@@ -1,0 +1,151 @@
+import { URLSearchParams } from 'url';
+
+type EmailPayload = {
+  to: string | string[];
+  subject: string;
+  text: string;
+  html?: string;
+  categories?: string[];
+  customArgs?: Record<string, string>;
+  from?: string;
+};
+
+type EmailResult = {
+  delivered: boolean;
+  provider: 'sendgrid' | 'stub';
+  messageId?: string;
+  status?: number;
+  preview?: {
+    to: string[];
+    subject: string;
+    text: string;
+    html?: string;
+  };
+  error?: string;
+};
+
+type SmsPayload = {
+  to: string;
+  body: string;
+  from?: string;
+};
+
+type SmsResult = {
+  delivered: boolean;
+  provider: 'twilio' | 'stub';
+  sid?: string;
+  status?: number;
+  preview?: {
+    to: string;
+    from?: string;
+    body: string;
+  };
+  error?: string;
+};
+
+function normalizeRecipients(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+export async function sendEmail(payload: EmailPayload): Promise<EmailResult> {
+  const to = normalizeRecipients(payload.to);
+  const fromEmail =
+    payload.from || process.env.SENDGRID_FROM_EMAIL || 'sdoh-bridge@example.com';
+
+  if (!process.env.SENDGRID_API_KEY) {
+    const preview = { to, subject: payload.subject, text: payload.text, html: payload.html };
+    console.info('[notifications] SENDGRID_API_KEY missing – returning preview', preview);
+    return { delivered: false, provider: 'stub', preview, error: 'SENDGRID_API_KEY not configured' };
+  }
+
+  const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.SENDGRID_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      personalizations: [
+        {
+          to: to.map((email) => ({ email })),
+          custom_args: payload.customArgs,
+          categories: payload.categories,
+        },
+      ],
+      from: { email: fromEmail },
+      subject: payload.subject,
+      content: [
+        { type: 'text/plain', value: payload.text },
+        ...(payload.html ? [{ type: 'text/html', value: payload.html }] : []),
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    const preview = { to, subject: payload.subject, text: payload.text, html: payload.html };
+    console.error('[notifications] SendGrid API error', response.status, errorText);
+    return {
+      delivered: false,
+      provider: 'sendgrid',
+      status: response.status,
+      preview,
+      error: `SendGrid request failed: ${errorText}`,
+    };
+  }
+
+  return {
+    delivered: true,
+    provider: 'sendgrid',
+    status: response.status,
+    messageId: response.headers.get('x-message-id') || undefined,
+  };
+}
+
+export async function sendSms(payload: SmsPayload): Promise<SmsResult> {
+  const fromNumber = payload.from || process.env.TWILIO_FROM_NUMBER;
+  if (!process.env.TWILIO_ACCOUNT_SID || !process.env.TWILIO_AUTH_TOKEN || !fromNumber) {
+    const preview = { to: payload.to, from: fromNumber, body: payload.body };
+    console.info('[notifications] Twilio env missing – returning preview', preview);
+    return { delivered: false, provider: 'stub', preview, error: 'Twilio credentials not configured' };
+  }
+
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${process.env.TWILIO_ACCOUNT_SID}/Messages.json`;
+  const params = new URLSearchParams({
+    To: payload.to,
+    From: fromNumber,
+    Body: payload.body,
+  });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${process.env.TWILIO_ACCOUNT_SID}:${process.env.TWILIO_AUTH_TOKEN}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    const preview = { to: payload.to, from: fromNumber, body: payload.body };
+    console.error('[notifications] Twilio API error', response.status, errorText);
+    return {
+      delivered: false,
+      provider: 'twilio',
+      status: response.status,
+      preview,
+      error: `Twilio request failed: ${errorText}`,
+    };
+  }
+
+  const data = (await response.json()) as { sid?: string };
+  return {
+    delivered: true,
+    provider: 'twilio',
+    status: response.status,
+    sid: data.sid,
+  };
+}
+
+export type { EmailPayload, EmailResult, SmsPayload, SmsResult };

--- a/server/src/services/scenarioPipeline.ts
+++ b/server/src/services/scenarioPipeline.ts
@@ -1,0 +1,522 @@
+import { detectConversation, type DetectionRequest, type DetectionResponse } from './sdohEngine';
+import { sendEmail, sendSms, type EmailResult, type SmsResult } from './notifications';
+
+type ConversationMessage = DetectionRequest['transcript'][number];
+
+type CareCoordinationCallRequest = {
+  memberId: string;
+  caseManagerEmail: string;
+  workerName?: string;
+  workerEmail?: string;
+  encounterId?: string;
+  transcript: ConversationMessage[];
+  context?: DetectionRequest['context'];
+};
+
+type CareCoordinationCallResponse = {
+  detection: DetectionResponse;
+  email: EmailResult;
+  taskSummary: {
+    memberId: string;
+    workerName?: string;
+    encounterId?: string;
+    nextActions: string[];
+  };
+};
+
+type SmsScreeningRequest = {
+  memberId: string;
+  outreachPrompt: string;
+  memberReply: string;
+  memberPhone: string;
+  coordinatorEmail: string;
+  fromNumber?: string;
+};
+
+type SmsScreeningResponse = {
+  detection: DetectionResponse;
+  autoReply: string;
+  sms: SmsResult;
+  email: EmailResult;
+};
+
+type EhrIntakeRequest = {
+  memberId: string;
+  encounterId?: string;
+  responses: Record<string, string | number | boolean | null | undefined>;
+  additionalNote?: string;
+  destinationEmail: string;
+};
+
+type EhrIntakeResponse = {
+  detection: DetectionResponse;
+  fhirBundle: Record<string, unknown>;
+  email: EmailResult;
+};
+
+type MonitoringRequest = {
+  memberId: string;
+  checkInId?: string;
+  responses: {
+    prompt: string;
+    reply: string;
+    channel: 'voice' | 'sms';
+    timestamp?: string;
+  }[];
+  notifyEmails: string[];
+};
+
+type MonitoringResponse = {
+  detection: DetectionResponse;
+  priority: 'routine' | 'needs_follow_up' | 'urgent';
+  alerts: string[];
+  email: EmailResult;
+};
+
+type CareTeamAlertRequest = {
+  memberId: string;
+  transcript: ConversationMessage[];
+  dashboardUrl?: string;
+  notifyEmails: string[];
+};
+
+type CareTeamAlertResponse = {
+  detection: DetectionResponse;
+  alert: {
+    severity: 'info' | 'warning' | 'critical';
+    summary: string;
+    dashboardUrl?: string;
+  };
+  email: EmailResult;
+};
+
+type PopulationHealthRequest = {
+  tenantId?: string;
+  cohort: {
+    memberId: string;
+    transcript: ConversationMessage[];
+    context?: DetectionRequest['context'];
+  }[];
+};
+
+type PopulationHealthResponse = {
+  tenantId?: string;
+  detections: DetectionResponse[];
+  metrics: {
+    highRiskMembers: number;
+    totalMembers: number;
+    potentialRevenue: number;
+    topIssues: {
+      code: string;
+      label: string;
+      count: number;
+    }[];
+  };
+};
+
+type PostDischargeRequest = {
+  memberId: string;
+  memberPhone: string;
+  careTeamEmail: string;
+  encounterId?: string;
+  dischargeSummary?: string;
+  memberReply: string;
+  fromNumber?: string;
+};
+
+type PostDischargeResponse = {
+  detection: DetectionResponse;
+  autoReply: string;
+  sms: SmsResult;
+  email: EmailResult;
+};
+
+function buildActionPlan(detection: DetectionResponse): string[] {
+  if (detection.issues.length === 0) {
+    return ['Document as no active SDOH risk. Maintain standard outreach cadence.'];
+  }
+
+  return detection.issues.map((issue) => {
+    if (issue.urgency === 'high' || issue.severity === 'high') {
+      return `${issue.label}: escalate to care manager within 24 hours and document interventions.`;
+    }
+    if (issue.severity === 'moderate') {
+      return `${issue.label}: queue resource referral and schedule follow-up in 3-5 days.`;
+    }
+    return `${issue.label}: monitor and address during next monthly touchpoint.`;
+  });
+}
+
+function buildEmailTable(detection: DetectionResponse): string {
+  if (detection.issues.length === 0) {
+    return '<p><strong>No active SDOH issues detected.</strong></p>';
+  }
+
+  const rows = detection.issues
+    .map(
+      (issue) =>
+        `<tr><td>${issue.code}</td><td>${issue.label}</td><td>${issue.severity}</td><td>${issue.urgency}</td><td>${issue.confidence}</td></tr>`
+    )
+    .join('');
+
+  return `
+    <table border="1" cellpadding="6" cellspacing="0">
+      <thead>
+        <tr>
+          <th>Code</th>
+          <th>Label</th>
+          <th>Severity</th>
+          <th>Urgency</th>
+          <th>Confidence</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+}
+
+function buildSummaryText(detection: DetectionResponse): string {
+  if (detection.issues.length === 0) {
+    return 'No active SDOH risks identified. Maintain routine screening cadence.';
+  }
+
+  return detection.issues
+    .map((issue) => `${issue.label} (${issue.code}) — severity ${issue.severity}, urgency ${issue.urgency}.`)
+    .join('\n');
+}
+
+function createFhirBundle(request: EhrIntakeRequest, detection: DetectionResponse): Record<string, unknown> {
+  const issued = new Date().toISOString();
+  return {
+    resourceType: 'Bundle',
+    type: 'collection',
+    id: `bundle-${request.memberId}-${Date.now()}`,
+    meta: {
+      lastUpdated: issued,
+      tag: [{ system: 'https://sdoh-bridge.example.com', code: 'intake-ai-summary' }],
+    },
+    entry: [
+      {
+        resource: {
+          resourceType: 'QuestionnaireResponse',
+          id: `qr-${request.memberId}-${Date.now()}`,
+          status: 'completed',
+          authored: issued,
+          subject: { reference: `Patient/${request.memberId}` },
+          item: Object.entries(request.responses).map(([linkId, answer]) => ({
+            linkId,
+            text: linkId,
+            answer: [{ valueString: String(answer) }],
+          })),
+        },
+      },
+      ...detection.issues.map((issue, index) => ({
+        resource: {
+          resourceType: 'Condition',
+          id: `condition-${index}`,
+          subject: { reference: `Patient/${request.memberId}` },
+          code: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/sid/icd-10',
+                code: issue.code,
+                display: issue.label,
+              },
+            ],
+            text: issue.label,
+          },
+          clinicalStatus: { text: issue.status },
+          recordedDate: issued,
+          extension: [
+            { url: 'https://sdoh-bridge.example.com/severity', valueString: issue.severity },
+            { url: 'https://sdoh-bridge.example.com/urgency', valueString: issue.urgency },
+          ],
+        },
+      })),
+    ],
+  };
+}
+
+function pickPriority(detection: DetectionResponse): 'routine' | 'needs_follow_up' | 'urgent' {
+  if (detection.issues.some((issue) => issue.urgency === 'high')) {
+    return 'urgent';
+  }
+  if (detection.issues.some((issue) => issue.severity !== 'low')) {
+    return 'needs_follow_up';
+  }
+  return 'routine';
+}
+
+export async function processCareCoordinationCall(
+  request: CareCoordinationCallRequest
+): Promise<CareCoordinationCallResponse> {
+  const detection = await detectConversation({
+    memberId: request.memberId,
+    transcript: request.transcript,
+    context: request.context ?? { encounterId: request.encounterId },
+  });
+
+  const actions = buildActionPlan(detection);
+  const html = `
+    <h2>SDOH Summary for ${request.memberId}</h2>
+    <p>Worker: ${request.workerName ?? 'Unknown'} (${request.workerEmail ?? 'n/a'})</p>
+    ${buildEmailTable(detection)}
+    <h3>Next steps</h3>
+    <ul>${actions.map((action) => `<li>${action}</li>`).join('')}</ul>
+  `;
+
+  const email = await sendEmail({
+    to: request.caseManagerEmail,
+    subject: `SDOH summary for ${request.memberId}`,
+    text: buildSummaryText(detection),
+    html,
+    customArgs: {
+      memberId: request.memberId,
+      scenario: 'care-coordination-call',
+    },
+  });
+
+  return {
+    detection,
+    email,
+    taskSummary: {
+      memberId: request.memberId,
+      workerName: request.workerName,
+      encounterId: request.encounterId,
+      nextActions: actions,
+    },
+  };
+}
+
+export async function processSmsScreening(
+  request: SmsScreeningRequest
+): Promise<SmsScreeningResponse> {
+  const transcript: ConversationMessage[] = [
+    { speaker: 'system', text: request.outreachPrompt },
+    { speaker: 'member', text: request.memberReply },
+  ];
+
+  const detection = await detectConversation({ memberId: request.memberId, transcript });
+  const reply = detection.issues.length
+    ? 'Thanks for sharing. A care coordinator will reach out shortly with food and housing resources.'
+    : 'Thank you for the update! We are here if you need any support.';
+
+  const sms = await sendSms({ to: request.memberPhone, from: request.fromNumber, body: reply });
+  const email = await sendEmail({
+    to: request.coordinatorEmail,
+    subject: `SMS screening update for ${request.memberId}`,
+    text: buildSummaryText(detection),
+    html: `
+      <p>Member response:</p>
+      <blockquote>${request.memberReply}</blockquote>
+      ${buildEmailTable(detection)}
+    `,
+    customArgs: {
+      memberId: request.memberId,
+      scenario: 'sms-screening',
+    },
+  });
+
+  return { detection, autoReply: reply, sms, email };
+}
+
+export async function processEhrIntake(request: EhrIntakeRequest): Promise<EhrIntakeResponse> {
+  const transcript: ConversationMessage[] = Object.entries(request.responses).map(([key, value]) => ({
+    speaker: 'intake_form',
+    text: `${key}: ${value}`,
+  }));
+  if (request.additionalNote) {
+    transcript.push({ speaker: 'staff_note', text: request.additionalNote });
+  }
+
+  const detection = await detectConversation({
+    memberId: request.memberId,
+    transcript,
+    context: { encounterId: request.encounterId },
+  });
+
+  const fhirBundle = createFhirBundle(request, detection);
+  const email = await sendEmail({
+    to: request.destinationEmail,
+    subject: `EHR intake SDOH bundle for ${request.memberId}`,
+    text: buildSummaryText(detection),
+    html: `
+      <p>Attached SDOH bundle for encounter ${request.encounterId ?? 'n/a'}.</p>
+      ${buildEmailTable(detection)}
+      <pre>${JSON.stringify(fhirBundle, null, 2)}</pre>
+    `,
+    categories: ['ehr-intake'],
+    customArgs: {
+      memberId: request.memberId,
+      scenario: 'ehr-intake',
+    },
+  });
+
+  return { detection, fhirBundle, email };
+}
+
+export async function processMonitoringCheckIn(
+  request: MonitoringRequest
+): Promise<MonitoringResponse> {
+  const transcript: ConversationMessage[] = request.responses.map((entry) => ({
+    speaker: entry.channel === 'voice' ? 'member_voice' : 'member_sms',
+    text: `${entry.prompt} ${entry.reply}`,
+    timestamp: entry.timestamp,
+  }));
+
+  const detection = await detectConversation({ memberId: request.memberId, transcript });
+  const priority = pickPriority(detection);
+  const alerts = buildActionPlan(detection);
+  const email = await sendEmail({
+    to: request.notifyEmails,
+    subject: `Check-in ${request.checkInId ?? ''} status for ${request.memberId}`.trim(),
+    text: buildSummaryText(detection),
+    html: `
+      <p>Priority: <strong>${priority}</strong></p>
+      ${buildEmailTable(detection)}
+      <h3>Actions</h3>
+      <ul>${alerts.map((alert) => `<li>${alert}</li>`).join('')}</ul>
+    `,
+    customArgs: {
+      memberId: request.memberId,
+      scenario: 'monitoring',
+    },
+  });
+
+  return { detection, priority, alerts, email };
+}
+
+export async function processCareTeamAlert(
+  request: CareTeamAlertRequest
+): Promise<CareTeamAlertResponse> {
+  const detection = await detectConversation({ memberId: request.memberId, transcript: request.transcript });
+  const highRisk = detection.issues.filter((issue) => issue.urgency === 'high' || issue.severity === 'high');
+  const severity = highRisk.length >= 2 ? 'critical' : highRisk.length === 1 ? 'warning' : 'info';
+  const summary =
+    highRisk.length > 0
+      ? `Multiple high-risk SDOH issues detected: ${highRisk.map((issue) => issue.label).join(', ')}.`
+      : 'No high-risk SDOH findings in latest review.';
+
+  const email = await sendEmail({
+    to: request.notifyEmails,
+    subject: `Care team alert for ${request.memberId}`,
+    text: `${summary}\n${buildSummaryText(detection)}`,
+    html: `
+      <p>Severity: <strong>${severity}</strong></p>
+      ${buildEmailTable(detection)}
+      ${request.dashboardUrl ? `<p><a href="${request.dashboardUrl}">Open in dashboard</a></p>` : ''}
+    `,
+    customArgs: {
+      memberId: request.memberId,
+      scenario: 'care-team-alert',
+    },
+  });
+
+  return {
+    detection,
+    alert: {
+      severity,
+      summary,
+      dashboardUrl: request.dashboardUrl,
+    },
+    email,
+  };
+}
+
+export async function processPopulationHealth(
+  request: PopulationHealthRequest
+): Promise<PopulationHealthResponse> {
+  const detections: DetectionResponse[] = [];
+  for (const cohortMember of request.cohort) {
+    const detection = await detectConversation({
+      memberId: cohortMember.memberId,
+      transcript: cohortMember.transcript,
+      context: cohortMember.context,
+    });
+    detections.push(detection);
+  }
+
+  const issueCounts = new Map<string, { code: string; label: string; count: number }>();
+  let potentialRevenue = 0;
+  for (const detection of detections) {
+    for (const issue of detection.issues) {
+      potentialRevenue += issue.estimatedRevenue;
+      const current = issueCounts.get(issue.code) ?? { code: issue.code, label: issue.label, count: 0 };
+      current.count += 1;
+      issueCounts.set(issue.code, current);
+    }
+  }
+
+  const topIssues = Array.from(issueCounts.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  const highRiskMembers = detections.filter((detection) =>
+    detection.issues.some((issue) => issue.severity === 'high' || issue.urgency === 'high')
+  ).length;
+
+  return {
+    tenantId: request.tenantId,
+    detections,
+    metrics: {
+      highRiskMembers,
+      totalMembers: request.cohort.length,
+      potentialRevenue: parseFloat(potentialRevenue.toFixed(2)),
+      topIssues,
+    },
+  };
+}
+
+export async function processPostDischarge(
+  request: PostDischargeRequest
+): Promise<PostDischargeResponse> {
+  const transcript: ConversationMessage[] = [
+    ...(request.dischargeSummary ? [{ speaker: 'summary', text: request.dischargeSummary }] : []),
+    { speaker: 'member', text: request.memberReply },
+  ];
+
+  const detection = await detectConversation({
+    memberId: request.memberId,
+    transcript,
+    context: { encounterId: request.encounterId },
+  });
+
+  const reply = detection.issues.length
+    ? 'We will connect you with our social work team right away to help with medications and groceries.'
+    : 'Thank you for the update. Let us know if anything changes.';
+
+  const sms = await sendSms({ to: request.memberPhone, from: request.fromNumber, body: reply });
+  const email = await sendEmail({
+    to: request.careTeamEmail,
+    subject: `Post-discharge SDOH follow-up for ${request.memberId}`,
+    text: buildSummaryText(detection),
+    html: `
+      <p>Member reply:</p>
+      <blockquote>${request.memberReply}</blockquote>
+      ${buildEmailTable(detection)}
+    `,
+    customArgs: {
+      memberId: request.memberId,
+      scenario: 'post-discharge',
+    },
+  });
+
+  return { detection, autoReply: reply, sms, email };
+}
+
+export type {
+  CareCoordinationCallRequest,
+  CareCoordinationCallResponse,
+  SmsScreeningRequest,
+  SmsScreeningResponse,
+  EhrIntakeRequest,
+  EhrIntakeResponse,
+  MonitoringRequest,
+  MonitoringResponse,
+  CareTeamAlertRequest,
+  CareTeamAlertResponse,
+  PopulationHealthRequest,
+  PopulationHealthResponse,
+  PostDischargeRequest,
+  PostDischargeResponse,
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,2 +1,25 @@
+import { useEffect, useState } from 'react';
 import Member from './pages/Member';
-export default function App(){ return <Member/> }
+import ScenariosDashboard from './pages/ScenariosDashboard';
+
+function usePathname() {
+  const [path, setPath] = useState(() => window.location.pathname);
+
+  useEffect(() => {
+    const handler = () => setPath(window.location.pathname);
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  return path;
+}
+
+export default function App() {
+  const path = usePathname();
+
+  if (path.startsWith('/scenarios')) {
+    return <ScenariosDashboard />;
+  }
+
+  return <Member />;
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -61,6 +61,19 @@ export type DetectionResponse = {
   debug?: { fallbackUsed: boolean; model?: string };
 };
 
+export type DetectionRunRecord = {
+  id: string;
+  scenarioId: string;
+  scenarioName: string;
+  memberId: string;
+  memberName?: string | null;
+  issues: DetectionResponse['issues'];
+  narrative?: string | null;
+  revenue?: DetectionResponse['revenue'] | null;
+  compliance?: DetectionResponse['compliance'] | null;
+  createdAt: string;
+};
+
 export const api = {
   createScreening: (body: any) =>
     fetch(`${base}/api/screenings`, {
@@ -91,5 +104,34 @@ export const api = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
+    }).then((r) => r.json()),
+  sendSummaryEmail: (payload: {
+    to: string[];
+    scenarioId?: string;
+    scenarioName: string;
+    memberId: string;
+    memberName?: string;
+    detection: DetectionResponse;
+  }) =>
+    fetch(`${base}/api/ai/send-summary`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).then((r) => r.json()),
+  recordDetection: (payload: {
+    scenarioId: string;
+    scenarioName: string;
+    memberId: string;
+    memberName?: string;
+    detection: DetectionResponse;
+  }) =>
+    fetch(`${base}/api/ai/detections`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).then((r) => r.json()),
+  listDetections: (limit = 10): Promise<{ detections: DetectionRunRecord[] }> =>
+    fetch(`${base}/api/ai/detections?limit=${limit}`, {
+      headers: { 'Content-Type': 'application/json' },
     }).then((r) => r.json()),
 };

--- a/web/src/pages/ScenariosDashboard.tsx
+++ b/web/src/pages/ScenariosDashboard.tsx
@@ -1,0 +1,964 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { api, type DetectionResponse, type DetectionRunRecord } from '../api';
+
+type TranscriptMessage = {
+  speaker: string;
+  text: string;
+  language?: string;
+  timestamp?: string;
+};
+
+type ScenarioDefinition = {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  category: 'voice' | 'sms' | 'ehr' | 'monitoring' | 'alerts' | 'analytics' | 'post-discharge';
+  memberId: string;
+  memberName: string;
+  defaultRecipients: string[];
+  transcript: TranscriptMessage[];
+  context?: Record<string, unknown>;
+  participants: string[];
+};
+
+type ToastState = { message: string; tone: 'success' | 'error' } | null;
+
+const scenarios: ScenarioDefinition[] = [
+  {
+    id: 'care-coordination',
+    icon: '🩺',
+    title: 'Care Coordination Calls',
+    description: 'Document voice call SDOH risks with narrative summaries for case managers.',
+    category: 'voice',
+    memberId: 'member-1001',
+    memberName: 'Alex Rivera',
+    defaultRecipients: ['care.team+alex@example.org'],
+    participants: ['member', 'navigator', 'case-manager'],
+    transcript: [
+      {
+        speaker: 'navigator',
+        text: 'Hi Alex, thanks for taking the call. We are checking in on groceries and utilities this week.',
+        language: 'en',
+        timestamp: '2025-02-01T15:02:00Z',
+      },
+      {
+        speaker: 'member',
+        text: 'The pantry ran out of produce and I skipped dinner twice. Mi refrigerador está casi vacío.',
+        language: 'es',
+        timestamp: '2025-02-01T15:02:21Z',
+      },
+      {
+        speaker: 'member',
+        text: 'Our power bill is overdue and the company sent a shutoff warning for Friday.',
+        language: 'en',
+        timestamp: '2025-02-01T15:02:58Z',
+      },
+      {
+        speaker: 'navigator',
+        text: 'We will escalate LIHEAP and emergency food. Anything else impacting you?',
+        language: 'en',
+        timestamp: '2025-02-01T15:03:21Z',
+      },
+      {
+        speaker: 'member',
+        text: 'I sleep in the car sometimes to stay warm. Estoy muy preocupado.',
+        language: 'es',
+        timestamp: '2025-02-01T15:03:47Z',
+      },
+    ],
+    context: { requiredScreenings: 24, completedScreenings: 18, monthlyGoal: 30 },
+  },
+  {
+    id: 'sms-outreach',
+    icon: '💬',
+    title: 'Outreach SMS Screening',
+    description: 'Automate texting programs that triage food, housing, and transportation needs.',
+    category: 'sms',
+    memberId: 'member-2048',
+    memberName: 'María López',
+    defaultRecipients: ['outreach.team@example.org'],
+    participants: ['member', 'outreach-bot', 'care-coordinator'],
+    transcript: [
+      {
+        speaker: 'outreach-bot',
+        text: 'Hi María, checking in. Are you managing food and housing okay this week?',
+        language: 'en',
+        timestamp: '2025-02-03T18:18:00Z',
+      },
+      {
+        speaker: 'member',
+        text: "We're short on groceries and my landlord posted an eviction notice.",
+        language: 'en',
+        timestamp: '2025-02-03T18:18:17Z',
+      },
+      {
+        speaker: 'member',
+        text: 'También necesito ayuda con transporte para llegar a la clínica.',
+        language: 'es',
+        timestamp: '2025-02-03T18:18:42Z',
+      },
+      {
+        speaker: 'care-coordinator',
+        text: 'Thank you for sharing. We will schedule a follow-up to connect you with local food resources.',
+        language: 'en',
+        timestamp: '2025-02-03T18:19:08Z',
+      },
+    ],
+    context: { channel: 'sms', campaign: 'food-housing-outreach' },
+  },
+  {
+    id: 'ehr-intake',
+    icon: '🧾',
+    title: 'EHR Intake Form AI Screening',
+    description: 'Convert intake answers into Z-codes and FHIR attachments automatically.',
+    category: 'ehr',
+    memberId: 'member-3090',
+    memberName: 'Jordan Ellis',
+    defaultRecipients: ['ehr.integration@example.org'],
+    participants: ['member', 'intake-form', 'nurse'],
+    transcript: [
+      {
+        speaker: 'intake-form',
+        text: 'Do you currently have concerns about food, housing, or utilities?',
+        language: 'en',
+        timestamp: '2025-02-05T14:05:00Z',
+      },
+      {
+        speaker: 'member',
+        text: 'Yes, I ran out of groceries last week and the pantry is closed on weekends.',
+        language: 'en',
+        timestamp: '2025-02-05T14:05:36Z',
+      },
+      {
+        speaker: 'member',
+        text: 'My rent went up $400 and I cannot keep up. Estoy atrasado con el pago.',
+        language: 'es',
+        timestamp: '2025-02-05T14:06:12Z',
+      },
+      {
+        speaker: 'nurse',
+        text: 'Thank you, we will document this and connect you to housing navigation.',
+        language: 'en',
+        timestamp: '2025-02-05T14:06:45Z',
+      },
+    ],
+    context: { encounterId: 'enc-3090', site: 'Greenwood Community Health' },
+  },
+  {
+    id: 'elderly-check-in',
+    icon: '👵',
+    title: 'Elderly Weekly Check-In',
+    description: 'Blend voice + SMS responses from aging members to escalate urgent needs.',
+    category: 'monitoring',
+    memberId: 'member-4120',
+    memberName: 'Evelyn Smith',
+    defaultRecipients: ['aging.services@example.org'],
+    participants: ['member', 'ivr', 'care-navigator'],
+    transcript: [
+      {
+        speaker: 'ivr',
+        text: 'Press 1 if you are having trouble affording groceries this week.',
+        language: 'en',
+        timestamp: '2025-02-07T10:01:00Z',
+      },
+      {
+        speaker: 'member',
+        text: 'I pressed 1. The store prices doubled and my pantry is empty.',
+        language: 'en',
+        timestamp: '2025-02-07T10:01:22Z',
+      },
+      {
+        speaker: 'member',
+        text: 'También necesito transporte para mi cita cardiológica.',
+        language: 'es',
+        timestamp: '2025-02-07T10:01:58Z',
+      },
+      {
+        speaker: 'care-navigator',
+        text: 'Noted Evelyn, we will send a care coordinator to follow up today.',
+        language: 'en',
+        timestamp: '2025-02-07T10:02:31Z',
+      },
+    ],
+    context: { channel: 'voice', cadence: 'weekly' },
+  },
+  {
+    id: 'care-team-alerts',
+    icon: '🚨',
+    title: 'Care Team Alerts',
+    description: 'Trigger critical alerts when multiple SDOH risks are detected.',
+    category: 'alerts',
+    memberId: 'member-5233',
+    memberName: 'Samuel Green',
+    defaultRecipients: ['quality.team@example.org'],
+    participants: ['member', 'nurse', 'social-worker'],
+    transcript: [
+      {
+        speaker: 'nurse',
+        text: 'Samuel, tell me how you are doing with housing and medication today.',
+        language: 'en',
+        timestamp: '2025-02-08T09:10:00Z',
+      },
+      {
+        speaker: 'member',
+        text: 'I am sleeping on my sister’s couch. The shelter waitlist is 6 weeks.',
+        language: 'en',
+        timestamp: '2025-02-08T09:10:25Z',
+      },
+      {
+        speaker: 'member',
+        text: 'No puedo pagar mis medicamentos para la diabetes este mes.',
+        language: 'es',
+        timestamp: '2025-02-08T09:11:00Z',
+      },
+      {
+        speaker: 'social-worker',
+        text: 'We will prioritize your case and loop in the medication assistance team.',
+        language: 'en',
+        timestamp: '2025-02-08T09:11:40Z',
+      },
+    ],
+    context: { dashboardUrl: 'https://portal.example.org/care-team/tasks' },
+  },
+  {
+    id: 'population-analytics',
+    icon: '📊',
+    title: 'Population Health Analytics',
+    description: 'Aggregate AI detections for monthly compliance and revenue dashboards.',
+    category: 'analytics',
+    memberId: 'cohort-analytics',
+    memberName: 'Cohort Summary',
+    defaultRecipients: ['population.health@example.org'],
+    participants: ['analyst', 'ai-engine'],
+    transcript: [
+      {
+        speaker: 'analyst',
+        text: 'Generate a report for January cohorts with AI-detected SDOH trends.',
+        language: 'en',
+        timestamp: '2025-02-09T12:20:00Z',
+      },
+      {
+        speaker: 'ai-engine',
+        text: 'Detected 128 members with food insecurity and 74 with housing instability.',
+        language: 'en',
+        timestamp: '2025-02-09T12:20:33Z',
+      },
+      {
+        speaker: 'ai-engine',
+        text: 'Average screening completion 82%. Revenue lift estimate $214,000.',
+        language: 'en',
+        timestamp: '2025-02-09T12:21:05Z',
+      },
+      {
+        speaker: 'analyst',
+        text: 'Highlight members overdue for screenings and compliance gaps.',
+        language: 'en',
+        timestamp: '2025-02-09T12:21:41Z',
+      },
+    ],
+    context: { cohortSize: 420, reportingMonth: '2025-01' },
+  },
+  {
+    id: 'post-discharge',
+    icon: '🏥',
+    title: 'Post-Discharge Follow-Up',
+    description: 'Capture barriers after discharge and route referrals instantly.',
+    category: 'post-discharge',
+    memberId: 'member-6344',
+    memberName: 'Tiana Brooks',
+    defaultRecipients: ['transitions@example.org'],
+    participants: ['member', 'transition-nurse'],
+    transcript: [
+      {
+        speaker: 'transition-nurse',
+        text: 'Hi Tiana, were you able to pick up your medications after leaving the hospital?',
+        language: 'en',
+        timestamp: '2025-02-10T16:45:00Z',
+      },
+      {
+        speaker: 'member',
+        text: 'No, I could not afford the copay and I have no ride to the pharmacy.',
+        language: 'en',
+        timestamp: '2025-02-10T16:45:32Z',
+      },
+      {
+        speaker: 'member',
+        text: 'También necesito comida suave porque mis encías duelen.',
+        language: 'es',
+        timestamp: '2025-02-10T16:46:01Z',
+      },
+      {
+        speaker: 'transition-nurse',
+        text: 'We will send a care coordinator with groceries and arrange medication delivery.',
+        language: 'en',
+        timestamp: '2025-02-10T16:46:28Z',
+      },
+    ],
+    context: { dischargeDate: '2025-02-08', encounterId: 'enc-6344' },
+  },
+];
+
+type ScenarioFilterValue = ScenarioDefinition['category'] | 'all';
+
+const scenarioFilters: { value: ScenarioFilterValue; label: string }[] = [
+  { value: 'all', label: 'All scenarios' },
+  { value: 'voice', label: 'Voice' },
+  { value: 'sms', label: 'SMS' },
+  { value: 'ehr', label: 'EHR' },
+  { value: 'monitoring', label: 'Monitoring' },
+  { value: 'alerts', label: 'Alerts' },
+  { value: 'analytics', label: 'Analytics' },
+  { value: 'post-discharge', label: 'Post-discharge' },
+];
+
+const timeFilters = [
+  { value: '24h', label: 'Last 24h' },
+  { value: '7d', label: '7 days' },
+  { value: '30d', label: '30 days' },
+  { value: 'all', label: 'All time' },
+];
+
+type TimeFilterValue = (typeof timeFilters)[number]['value'];
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+export default function ScenariosDashboard() {
+  const [selectedScenarioId, setSelectedScenarioId] = useState<string>(scenarios[0]?.id ?? '');
+  const [transcripts, setTranscripts] = useState<Record<string, TranscriptMessage[]>>(() => {
+    const initial: Record<string, TranscriptMessage[]> = {};
+    for (const scenario of scenarios) {
+      initial[scenario.id] = scenario.transcript;
+    }
+    return initial;
+  });
+  const [detections, setDetections] = useState<Record<string, DetectionResponse | null>>({});
+  const [recentDetections, setRecentDetections] = useState<DetectionRunRecord[]>([]);
+  const [loadingScenario, setLoadingScenario] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastState>(null);
+  const [scenarioFilter, setScenarioFilter] = useState<ScenarioFilterValue>('all');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [timeFilter, setTimeFilter] = useState<TimeFilterValue>('30d');
+  const [draftMessage, setDraftMessage] = useState<{ speaker: string; text: string; language: string }>({
+    speaker: scenarios[0]?.participants[0] ?? 'member',
+    text: '',
+    language: '',
+  });
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  const selectedScenario = useMemo(
+    () => scenarios.find((scenario) => scenario.id === selectedScenarioId) ?? scenarios[0],
+    [selectedScenarioId]
+  );
+
+  const scenarioMessages = transcripts[selectedScenarioId] ?? [];
+  const activeDetection = detections[selectedScenarioId] ?? null;
+
+  const transcriptLanguages = useMemo(() => {
+    const langs = new Set<string>();
+    scenarioMessages.forEach((message) => {
+      if (message.language) langs.add(message.language);
+    });
+    return Array.from(langs);
+  }, [scenarioMessages]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await api.listDetections(25);
+        if (!cancelled) {
+          setRecentDetections(response.detections);
+        }
+      } catch (err) {
+        console.error('Failed to load detections', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedScenario) return;
+    setDraftMessage((current) => ({
+      speaker: selectedScenario.participants.includes(current.speaker)
+        ? current.speaker
+        : selectedScenario.participants[0] ?? 'member',
+      text: '',
+      language: '',
+    }));
+    setEditingIndex(null);
+  }, [selectedScenario]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timeout = setTimeout(() => setToast(null), 3600);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  const filteredScenarios = useMemo(() => {
+    return scenarios.filter((scenario) => {
+      const matchesFilter = scenarioFilter === 'all' || scenario.category === scenarioFilter;
+      const matchesSearch = scenario.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        scenario.description.toLowerCase().includes(searchTerm.toLowerCase());
+      return matchesFilter && matchesSearch;
+    });
+  }, [scenarioFilter, searchTerm]);
+
+  const filteredRecentDetections = useMemo(() => {
+    const now = Date.now();
+    const cutoff = (() => {
+      switch (timeFilter) {
+        case '24h':
+          return now - 24 * 60 * 60 * 1000;
+        case '7d':
+          return now - 7 * 24 * 60 * 60 * 1000;
+        case '30d':
+          return now - 30 * 24 * 60 * 60 * 1000;
+        default:
+          return 0;
+      }
+    })();
+    return recentDetections.filter((detection) => {
+      if (cutoff === 0) return true;
+      const created = new Date(detection.createdAt).getTime();
+      if (Number.isNaN(created)) return true;
+      return created >= cutoff;
+    });
+  }, [recentDetections, timeFilter]);
+
+  const issueFrequencyData = useMemo(() => {
+    const counts = new Map<string, { code: string; label: string; count: number }>();
+    filteredRecentDetections.forEach((record) => {
+      record.issues.forEach((issue) => {
+        if (!counts.has(issue.code)) {
+          counts.set(issue.code, { code: issue.code, label: issue.label, count: 0 });
+        }
+        counts.get(issue.code)!.count += 1;
+      });
+    });
+    return Array.from(counts.values())
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 6)
+      .map((item) => ({ name: `${item.code}`, label: item.label, count: item.count }));
+  }, [filteredRecentDetections]);
+
+  const confidenceByScenarioData = useMemo(() => {
+    const aggregate = new Map<string, { scenario: string; total: number; count: number }>();
+    filteredRecentDetections.forEach((record) => {
+      if (!aggregate.has(record.scenarioName)) {
+        aggregate.set(record.scenarioName, { scenario: record.scenarioName, total: 0, count: 0 });
+      }
+      const bucket = aggregate.get(record.scenarioName)!;
+      record.issues.forEach((issue) => {
+        bucket.total += issue.confidence;
+        bucket.count += 1;
+      });
+    });
+    return Array.from(aggregate.values()).map((entry) => ({
+      scenario: entry.scenario,
+      averageConfidence: entry.count ? Number((entry.total / entry.count).toFixed(2)) : 0,
+    }));
+  }, [filteredRecentDetections]);
+
+  const complianceTrendData = useMemo(() => {
+    return filteredRecentDetections
+      .filter((record) => typeof record.compliance?.completionRate === 'number')
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      .slice(-10)
+      .map((record) => ({
+        date: new Date(record.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+        rate: Number((record.compliance?.completionRate ?? 0).toFixed(2)),
+      }));
+  }, [filteredRecentDetections]);
+
+  const maxIssueCount = useMemo(
+    () => Math.max(1, ...issueFrequencyData.map((item) => item.count)),
+    [issueFrequencyData]
+  );
+
+  const confidencePercentData = useMemo(
+    () =>
+      confidenceByScenarioData.map((item) => ({
+        scenario: item.scenario,
+        percent: Math.round(item.averageConfidence * 1000) / 10,
+      })),
+    [confidenceByScenarioData]
+  );
+
+  async function runDetection() {
+    if (!selectedScenario) return;
+    const transcript = transcripts[selectedScenario.id] ?? [];
+    if (transcript.length === 0) {
+      setError('Add at least one message before running detection.');
+      return;
+    }
+
+    setLoadingScenario(selectedScenario.id);
+    setError(null);
+    try {
+      const detection = await api.detectTranscript({
+        memberId: selectedScenario.memberId,
+        transcript,
+        context: selectedScenario.context,
+      });
+      setDetections((prev) => ({ ...prev, [selectedScenario.id]: detection }));
+
+      try {
+        await api.recordDetection({
+          scenarioId: selectedScenario.id,
+          scenarioName: selectedScenario.title,
+          memberId: selectedScenario.memberId,
+          memberName: selectedScenario.memberName,
+          detection,
+        });
+        const refreshed = await api.listDetections(25);
+        setRecentDetections(refreshed.detections);
+      } catch (recordError) {
+        console.warn('Failed to persist detection', recordError);
+      }
+    } catch (err) {
+      console.error(err);
+      setError('The AI engine could not process the transcript. Try again shortly.');
+    } finally {
+      setLoadingScenario(null);
+    }
+  }
+
+  async function sendSummaryEmail() {
+    if (!selectedScenario) return;
+    const detection = detections[selectedScenario.id];
+    if (!detection) return;
+    try {
+      await api.sendSummaryEmail({
+        to: selectedScenario.defaultRecipients,
+        scenarioId: selectedScenario.id,
+        scenarioName: selectedScenario.title,
+        memberId: selectedScenario.memberId,
+        memberName: selectedScenario.memberName,
+        detection,
+      });
+      setToast({ message: 'Email sent successfully to care team.', tone: 'success' });
+    } catch (err) {
+      console.error(err);
+      setToast({ message: 'Unable to send summary email. Check SendGrid settings.', tone: 'error' });
+    }
+  }
+
+  function startEditMessage(index: number) {
+    const message = scenarioMessages[index];
+    if (!message || !selectedScenario) return;
+    setDraftMessage({
+      speaker: message.speaker,
+      text: message.text,
+      language: message.language ?? '',
+    });
+    setEditingIndex(index);
+  }
+
+  function removeMessage(index: number) {
+    setTranscripts((prev) => ({
+      ...prev,
+      [selectedScenarioId]: (prev[selectedScenarioId] ?? []).filter((_, idx) => idx !== index),
+    }));
+    setEditingIndex(null);
+    setDraftMessage((current) => ({ ...current, text: '', language: '' }));
+  }
+
+  function handleMessageSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!selectedScenario) return;
+    const text = draftMessage.text.trim();
+    if (!text) return;
+    const payload: TranscriptMessage = {
+      speaker: draftMessage.speaker,
+      text,
+      language: draftMessage.language.trim() || undefined,
+      timestamp: new Date().toISOString(),
+    };
+    setTranscripts((prev) => {
+      const existing = prev[selectedScenario.id] ?? [];
+      if (editingIndex !== null) {
+        const next = [...existing];
+        next.splice(editingIndex, 1, { ...existing[editingIndex], ...payload });
+        return { ...prev, [selectedScenario.id]: next };
+      }
+      return { ...prev, [selectedScenario.id]: [...existing, payload] };
+    });
+    setDraftMessage({ speaker: draftMessage.speaker, text: '', language: '' });
+    setEditingIndex(null);
+  }
+
+  return (
+    <div className="page-shell scenarios-shell">
+      <header className="scenarios-header">
+        <div>
+          <span className="hero-badge">SDOH AI Pipelines</span>
+          <h1>Scenario Control Center</h1>
+          <p>
+            Orchestrate care coordination, outreach, intake, monitoring, alerts, analytics, and post-discharge workflows — all
+            powered by the AI detection engine and SendGrid notifications.
+          </p>
+        </div>
+        <div className="scenarios-filters">
+          <label>
+            <span>Scenario type</span>
+            <select value={scenarioFilter} onChange={(event) => setScenarioFilter(event.target.value as ScenarioFilterValue)}>
+              {scenarioFilters.map((filter) => (
+                <option key={filter.value} value={filter.value}>
+                  {filter.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>Search</span>
+            <input
+              type="search"
+              placeholder="Search scenarios"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+            />
+          </label>
+          <label>
+            <span>Time filter</span>
+            <select value={timeFilter} onChange={(event) => setTimeFilter(event.target.value as TimeFilterValue)}>
+              {timeFilters.map((filter) => (
+                <option key={filter.value} value={filter.value}>
+                  {filter.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </header>
+
+      <section className="scenario-grid">
+        {filteredScenarios.map((scenario) => (
+          <button
+            key={scenario.id}
+            className={`scenario-card${scenario.id === selectedScenarioId ? ' scenario-card--active' : ''}`}
+            type="button"
+            onClick={() => setSelectedScenarioId(scenario.id)}
+          >
+            <div className="scenario-card__icon">{scenario.icon}</div>
+            <div>
+              <h3>{scenario.title}</h3>
+              <p>{scenario.description}</p>
+            </div>
+            <footer>
+              <span>{scenario.memberName}</span>
+              <span className="scenario-card__tag">{scenario.category}</span>
+            </footer>
+          </button>
+        ))}
+      </section>
+
+      {selectedScenario && (
+        <section className="scenario-detail">
+          <div className="transcript-panel">
+            <header>
+              <h2>
+                {selectedScenario.icon} {selectedScenario.title}
+              </h2>
+              <span className="status-pill">Member ID: {selectedScenario.memberId}</span>
+            </header>
+            <div className="transcript-messages">
+              {scenarioMessages.map((message, index) => (
+                <div
+                  key={`${message.timestamp ?? index}-${index}`}
+                  className={`message-bubble message-bubble--${message.speaker === 'member' ? 'member' : 'staff'}`}
+                >
+                  <div className="message-meta">
+                    <strong>{message.speaker}</strong>
+                    {message.language && <span className="message-language">{message.language}</span>}
+                    {message.timestamp && <time>{new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>}
+                  </div>
+                  <p>{message.text}</p>
+                  <div className="message-actions">
+                    <button type="button" onClick={() => startEditMessage(index)}>
+                      Edit
+                    </button>
+                    <button type="button" onClick={() => removeMessage(index)}>
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              ))}
+              {scenarioMessages.length === 0 && <p className="empty-state">No transcript messages yet. Add one below to get started.</p>}
+            </div>
+
+            <form className="add-message" onSubmit={handleMessageSubmit}>
+              <div className="add-message__controls">
+                <label>
+                  <span>Speaker</span>
+                  <select
+                    value={draftMessage.speaker}
+                    onChange={(event) => setDraftMessage((prev) => ({ ...prev, speaker: event.target.value }))}
+                  >
+                    {selectedScenario.participants.map((participant) => (
+                      <option key={participant} value={participant}>
+                        {participant}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  <span>Language</span>
+                  <input
+                    value={draftMessage.language}
+                    onChange={(event) => setDraftMessage((prev) => ({ ...prev, language: event.target.value }))}
+                    placeholder="en, es, ..."
+                  />
+                </label>
+              </div>
+              <textarea
+                placeholder="Add message"
+                value={draftMessage.text}
+                onChange={(event) => setDraftMessage((prev) => ({ ...prev, text: event.target.value }))}
+                rows={3}
+              />
+              <div className="add-message__actions">
+                <button className="btn" type="submit">
+                  {editingIndex !== null ? 'Update message' : 'Add message'}
+                </button>
+                {editingIndex !== null && (
+                  <button
+                    className="btn btn--glass"
+                    type="button"
+                    onClick={() => {
+                      setEditingIndex(null);
+                      setDraftMessage((prev) => ({ ...prev, text: '', language: '' }));
+                    }}
+                  >
+                    Cancel
+                  </button>
+                )}
+                <button
+                  className="btn btn--accent"
+                  type="button"
+                  onClick={runDetection}
+                  disabled={loadingScenario === selectedScenario.id}
+                >
+                  {loadingScenario === selectedScenario.id ? 'Analyzing…' : 'Run AI Detection'}
+                </button>
+              </div>
+            </form>
+            {error && <p className="error-banner">{error}</p>}
+          </div>
+
+          <div className="results-panel">
+            <header>
+              <h3>Detected SDOH Issues</h3>
+              {activeDetection && <span>{activeDetection.issues.length} issues</span>}
+            </header>
+            {!activeDetection && <p className="empty-state">Run the AI detection to see structured outputs.</p>}
+            {activeDetection && (
+              <ul className="issues-list">
+                {activeDetection.issues.map((issue) => (
+                  <li key={issue.code}>
+                    <div className="issue-header">
+                      <strong>
+                        {issue.code} · {issue.label}
+                      </strong>
+                      <span className={`issue-pill issue-pill--${issue.severity.toLowerCase()}`}>{issue.severity}</span>
+                    </div>
+                    <div className="issue-meta">
+                      <span>Urgency: {issue.urgency}</span>
+                      <span>Confidence: {(issue.confidence * 100).toFixed(1)}%</span>
+                    </div>
+                    <p>{issue.rationale}</p>
+                    {issue.evidence.length > 0 && (
+                      <details>
+                        <summary>Evidence ({issue.evidence.length})</summary>
+                        <ul>
+                          {issue.evidence.map((ev, idx) => (
+                            <li key={`${ev.quote}-${idx}`}>
+                              <span>{ev.speaker}</span>: “{ev.quote}”{' '}
+                              {ev.language && <em>({ev.language})</em>}
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {activeDetection && (
+              <button className="btn btn--glass send-email" type="button" onClick={sendSummaryEmail}>
+                📧 Send Summary Email
+              </button>
+            )}
+          </div>
+
+          <aside className="insights-panel">
+            <h3>AI Narrative & Insights</h3>
+            {activeDetection ? (
+              <>
+                <p className="narrative">{activeDetection.documentation.narrative}</p>
+                <div className="insight-block">
+                  <h4>Potential Revenue</h4>
+                  <p>${activeDetection.revenue.potentialRevenue.toLocaleString()}</p>
+                </div>
+                <div className="insight-block">
+                  <h4>Compliance completion</h4>
+                  <p>{activeDetection.compliance.completionRate.toFixed(1)}%</p>
+                </div>
+                {activeDetection.compliance.alerts.length > 0 && (
+                  <div className="insight-block">
+                    <h4>Alerts</h4>
+                    <ul>
+                      {activeDetection.compliance.alerts.map((alert, idx) => (
+                        <li key={`${alert.message}-${idx}`}>{alert.message}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </>
+            ) : (
+              <p className="empty-state">Insights will appear after the AI detection runs.</p>
+            )}
+            <div className="insight-block">
+              <h4>Languages</h4>
+              {transcriptLanguages.length ? (
+                <div className="language-tags">
+                  {transcriptLanguages.map((language) => (
+                    <span key={language}>{language}</span>
+                  ))}
+                </div>
+              ) : (
+                <p>No language metadata</p>
+              )}
+            </div>
+          </aside>
+        </section>
+      )}
+
+      <section className="analytics-section">
+        <div className="analytics-card">
+          <h3>Detected issues by frequency</h3>
+          {issueFrequencyData.length === 0 ? (
+            <p className="empty-state">Run detections to populate analytics.</p>
+          ) : (
+            <ul className="analytics-bars">
+              {issueFrequencyData.map((item) => (
+                <li key={item.name}>
+                  <div className="analytics-bars__label">
+                    <span>{item.name}</span>
+                    <span>{item.count}</span>
+                  </div>
+                  <div className="analytics-bars__meter">
+                    <span style={{ width: `${Math.round((item.count / maxIssueCount) * 100)}%` }} />
+                  </div>
+                  <p className="analytics-bars__caption">{item.label}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="analytics-card">
+          <h3>Average confidence by scenario</h3>
+          {confidencePercentData.length === 0 ? (
+            <p className="empty-state">Confidence metrics will appear after detections are saved.</p>
+          ) : (
+            <ul className="analytics-bars">
+              {confidencePercentData.map((item) => (
+                <li key={item.scenario}>
+                  <div className="analytics-bars__label">
+                    <span>{item.scenario}</span>
+                    <span>{item.percent.toFixed(1)}%</span>
+                  </div>
+                  <div className="analytics-bars__meter analytics-bars__meter--teal">
+                    <span style={{ width: `${Math.min(100, Math.max(0, item.percent))}%` }} />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="analytics-card">
+          <h3>Compliance rate trend</h3>
+          {complianceTrendData.length === 0 ? (
+            <p className="empty-state">No compliance trend data yet.</p>
+          ) : (
+            <ul className="compliance-trend">
+              {complianceTrendData.map((item) => (
+                <li key={`${item.date}-${item.rate}`}>
+                  <div className="compliance-trend__meta">
+                    <strong>{item.date}</strong>
+                    <span>{item.rate}%</span>
+                  </div>
+                  <div className="compliance-trend__meter">
+                    <span style={{ width: `${Math.min(100, Math.max(0, item.rate))}%` }} />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <section className="recent-detections">
+        <header>
+          <h2>Recent detections</h2>
+          <span>{filteredRecentDetections.length} records</span>
+        </header>
+        <div className="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Scenario</th>
+                <th>Member</th>
+                <th>Issues</th>
+                <th>Top issue</th>
+                <th>Potential revenue</th>
+                <th>Compliance</th>
+                <th>Detected at</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredRecentDetections.map((record) => {
+                const topIssue = record.issues[0];
+                return (
+                  <tr key={record.id}>
+                    <td>{record.scenarioName}</td>
+                    <td>{record.memberName ?? record.memberId}</td>
+                    <td>{record.issues.length}</td>
+                    <td>{topIssue ? `${topIssue.code} · ${topIssue.label}` : '—'}</td>
+                    <td>
+                      {typeof record.revenue?.potentialRevenue === 'number'
+                        ? `$${Number(record.revenue.potentialRevenue).toLocaleString()}`
+                        : '—'}
+                    </td>
+                    <td>
+                      {typeof record.compliance?.completionRate === 'number'
+                        ? `${Number(record.compliance.completionRate).toFixed(1)}%`
+                        : '—'}
+                    </td>
+                    <td>{formatDate(record.createdAt)}</td>
+                  </tr>
+                );
+              })}
+              {filteredRecentDetections.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="empty-state">
+                    No detections saved for this time range yet.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {toast && <div className={`toast toast--${toast.tone}`}>{toast.message}</div>}
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1209,3 +1209,484 @@ body {
     max-height: none;
   }
 }
+
+/* --- Scenarios dashboard overrides --- */
+.scenarios-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  padding: 40px 32px 80px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.scenarios-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.scenarios-subtitle {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: rgba(30, 64, 175, 0.7);
+  margin: 0;
+}
+
+.scenarios-description {
+  max-width: 540px;
+  line-height: 1.6;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.scenarios-profile {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 20px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.05);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.scenarios-profile strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.scenarios-profile span {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.scenarios-logo {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #22c55e, #0ea5e9);
+  font-size: 1.4rem;
+  color: #fff;
+}
+
+.scenarios-filters {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.scenarios-filters select,
+.scenarios-filters input[type='search'] {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  background: rgba(248, 250, 252, 0.94);
+  min-width: 200px;
+}
+
+.scenarios-grid,
+.scenario-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 22px;
+}
+
+.scenario-card {
+  border: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 22px;
+  border-radius: 22px;
+  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.scenario-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 25px 45px -36px rgba(15, 23, 42, 0.45);
+}
+
+.scenario-card--active {
+  border-color: rgba(79, 70, 229, 0.6);
+  box-shadow: 0 30px 60px -36px rgba(79, 70, 229, 0.55);
+}
+
+.scenario-card__icon,
+.scenario-icon {
+  font-size: 2rem;
+}
+
+.scenario-card h2,
+.scenario-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.scenario-card p {
+  margin: 0;
+  color: rgba(30, 41, 59, 0.7);
+  line-height: 1.5;
+}
+
+.scenario-cta {
+  margin-top: auto;
+  font-weight: 600;
+  color: #4338ca;
+}
+
+.primary-btn,
+.secondary-btn {
+  border: none;
+  border-radius: 14px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #f8fafc;
+  box-shadow: 0 16px 38px -22px rgba(99, 102, 241, 0.7);
+}
+
+.primary-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 46px -26px rgba(99, 102, 241, 0.8);
+}
+
+.primary-btn:disabled,
+.secondary-btn:disabled {
+  opacity: 0.65;
+  cursor: wait;
+}
+
+.secondary-btn {
+  background: rgba(15, 23, 42, 0.06);
+  color: rgba(15, 23, 42, 0.8);
+}
+
+.scenario-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 28px;
+  align-items: flex-start;
+}
+
+.scenario-main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.transcript-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.transcript-simulator {
+  background: rgba(248, 250, 252, 0.95);
+  border-radius: 24px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 18px 45px -34px rgba(15, 23, 42, 0.55);
+}
+
+.transcript-simulator ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(99, 102, 241, 0.12);
+}
+
+.message--member {
+  background: rgba(34, 197, 94, 0.15);
+}
+
+.message--navigator,
+.message--care-coordinator,
+.message--care-manager,
+.message--nurse,
+.message--ivr,
+.message--outreach-bot,
+.message--analyst,
+.message--community-worker,
+.message--case-manager,
+.message--pharmacist {
+  background: rgba(14, 165, 233, 0.15);
+}
+
+.message header {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 0.85rem;
+  color: rgba(30, 41, 59, 0.75);
+}
+
+.message textarea {
+  width: 100%;
+  min-height: 72px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  resize: vertical;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.language-chip {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.16);
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: #0369a1;
+  text-transform: uppercase;
+}
+
+.message-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.message-form input,
+.message-form select {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 10px 12px;
+  font-size: 0.9rem;
+}
+
+.detection-panel {
+  background: rgba(248, 250, 252, 0.95);
+  border-radius: 24px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 24px;
+  box-shadow: 0 18px 45px -34px rgba(15, 23, 42, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel-placeholder {
+  color: rgba(30, 41, 59, 0.55);
+  font-style: italic;
+}
+
+.issue-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.15);
+  color: #312e81;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.chip--neutral {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(15, 23, 42, 0.7);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+table th,
+table td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.severity,
+.urgency {
+  text-transform: capitalize;
+  font-weight: 600;
+}
+
+.severity--high,
+.urgency--high {
+  color: #b91c1c;
+}
+
+.severity--moderate,
+.urgency--medium {
+  color: #f97316;
+}
+
+.severity--low,
+.urgency--low {
+  color: #15803d;
+}
+
+.scenario-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: rgba(248, 250, 252, 0.95);
+  border-radius: 24px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 24px;
+  box-shadow: 0 18px 45px -34px rgba(15, 23, 42, 0.45);
+}
+
+.scenario-sidebar section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.language-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.alert {
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+}
+
+.alert--info {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.alert--warning {
+  background: rgba(250, 204, 21, 0.18);
+  color: #a16207;
+}
+
+.alert--critical {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+.analytics-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.analytics-card {
+  background: rgba(248, 250, 252, 0.96);
+  border-radius: 22px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 20px;
+  box-shadow: 0 18px 40px -34px rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recent-detections {
+  background: rgba(248, 250, 252, 0.96);
+  border-radius: 24px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 24px;
+  box-shadow: 0 18px 40px -34px rgba(15, 23, 42, 0.55);
+}
+
+.recent-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.table-subtitle {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(30, 41, 59, 0.6);
+}
+
+.toast {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  padding: 16px 20px;
+  border-radius: 16px;
+  font-weight: 600;
+  box-shadow: 0 25px 50px -28px rgba(15, 23, 42, 0.55);
+  color: #fff;
+}
+
+.toast--success {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+}
+
+.toast--error {
+  background: linear-gradient(135deg, #f97316, #ef4444);
+}
+
+@media (max-width: 960px) {
+  .scenario-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .scenario-sidebar {
+    position: relative;
+  }
+}
+
+@media (max-width: 640px) {
+  .scenarios-shell {
+    padding: 32px 20px 72px;
+  }
+
+  .transcript-simulator ul {
+    max-height: none;
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -199,6 +199,541 @@ body {
   box-shadow: none;
 }
 
+.scenarios-shell {
+  gap: 40px;
+}
+
+.scenarios-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 32px;
+  align-items: flex-start;
+}
+
+.scenarios-header h1 {
+  margin: 12px 0 8px;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+}
+
+.scenarios-filters {
+  display: flex;
+  gap: 16px;
+  background: rgba(15, 23, 42, 0.04);
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.scenarios-filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.72);
+}
+
+.scenarios-filters select,
+.scenarios-filters input {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.scenario-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.scenario-card {
+  border: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  background: rgba(248, 250, 252, 0.85);
+  border-radius: 20px;
+  text-align: left;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  min-height: 190px;
+}
+
+.scenario-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 25px 40px -30px rgba(15, 23, 42, 0.45);
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.scenario-card--active {
+  border-color: rgba(79, 70, 229, 0.65);
+  box-shadow: 0 28px 45px -28px rgba(79, 70, 229, 0.55);
+}
+
+.scenario-card__icon {
+  font-size: 2rem;
+}
+
+.scenario-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.scenario-card p {
+  margin: 0;
+  color: rgba(30, 41, 59, 0.75);
+}
+
+.scenario-card footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: rgba(30, 41, 59, 0.65);
+}
+
+.scenario-card__tag {
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: rgba(99, 102, 241, 0.12);
+  color: #4338ca;
+  text-transform: capitalize;
+}
+
+.scenario-detail {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.transcript-panel,
+.results-panel,
+.insights-panel {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 20px 45px -36px rgba(15, 23, 42, 0.65);
+}
+
+.transcript-panel header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.transcript-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 340px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.message-bubble {
+  background: rgba(99, 102, 241, 0.12);
+  border-radius: 18px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.message-bubble--member {
+  background: rgba(34, 197, 94, 0.14);
+}
+
+.message-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.85rem;
+  color: rgba(30, 41, 59, 0.7);
+}
+
+.message-language {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.18);
+  color: #0369a1;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+}
+
+.message-actions {
+  display: flex;
+  gap: 10px;
+  font-size: 0.8rem;
+}
+
+.message-actions button {
+  border: none;
+  background: transparent;
+  color: #4c1d95;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.add-message {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.add-message__controls {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.add-message__controls select,
+.add-message__controls input {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+}
+
+.add-message textarea {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 12px 14px;
+  font-size: 1rem;
+  resize: vertical;
+  min-height: 96px;
+}
+
+.add-message__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.error-banner {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.results-panel header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.issues-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.issues-list li {
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.issue-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.issue-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 0.85rem;
+  color: rgba(30, 41, 59, 0.7);
+}
+
+.issue-pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  text-transform: capitalize;
+}
+
+.issue-pill--high {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+}
+
+.issue-pill--moderate {
+  background: rgba(251, 191, 36, 0.2);
+  color: #a16207;
+}
+
+.issue-pill--low {
+  background: rgba(134, 239, 172, 0.25);
+  color: #15803d;
+}
+
+.send-email {
+  margin-top: 18px;
+  width: 100%;
+}
+
+.insights-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.insight-block {
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.insight-block h4 {
+  margin: 0 0 6px;
+  font-size: 0.95rem;
+  color: rgba(30, 41, 59, 0.8);
+}
+
+.narrative {
+  line-height: 1.5;
+  color: rgba(30, 41, 59, 0.9);
+}
+
+.language-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.language-tags span {
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: rgba(20, 184, 166, 0.16);
+  color: #0f766e;
+  font-weight: 600;
+}
+
+.analytics-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.analytics-card {
+  background: rgba(248, 250, 252, 0.92);
+  border-radius: 22px;
+  padding: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 18px 40px -34px rgba(15, 23, 42, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.analytics-bars {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.analytics-bars__label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+
+.analytics-bars__meter {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.18);
+  overflow: hidden;
+}
+
+.analytics-bars__meter span {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.analytics-bars__meter--teal {
+  background: rgba(13, 148, 136, 0.2);
+}
+
+.analytics-bars__meter--teal span {
+  background: linear-gradient(135deg, #14b8a6, #0ea5e9);
+}
+
+.analytics-bars__caption {
+  margin: 6px 0 0;
+  font-size: 0.8rem;
+  color: rgba(30, 41, 59, 0.6);
+}
+
+.compliance-trend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.compliance-trend__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+
+.compliance-trend__meter {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(249, 115, 22, 0.18);
+  overflow: hidden;
+}
+
+.compliance-trend__meter span {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(135deg, #f97316, #fb7185);
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.recent-detections header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  background: rgba(248, 250, 252, 0.92);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.table-wrapper table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.table-wrapper th,
+.table-wrapper td {
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.7);
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.table-wrapper th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(30, 41, 59, 0.6);
+}
+
+.empty-state {
+  color: rgba(30, 41, 59, 0.6);
+  text-align: center;
+}
+
+.toast {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+  padding: 14px 18px;
+  border-radius: 16px;
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 25px 45px -30px rgba(15, 23, 42, 0.6);
+}
+
+.toast--success {
+  background: linear-gradient(135deg, #22c55e, #0ea5e9);
+}
+
+.toast--error {
+  background: linear-gradient(135deg, #f97316, #dc2626);
+}
+
+@media (max-width: 1200px) {
+  .scenario-detail {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-areas:
+      'transcript results'
+      'insights insights';
+  }
+
+  .transcript-panel {
+    grid-area: transcript;
+  }
+
+  .results-panel {
+    grid-area: results;
+  }
+
+  .insights-panel {
+    grid-area: insights;
+  }
+}
+
+@media (max-width: 920px) {
+  .scenario-detail {
+    grid-template-columns: 1fr;
+  }
+
+  .scenarios-header {
+    flex-direction: column;
+  }
+
+  .scenarios-filters {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 640px) {
+  .scenarios-filters {
+    flex-direction: column;
+  }
+
+  .analytics-section {
+    grid-template-columns: 1fr;
+  }
+}
+
 .inline-error {
   margin-top: 18px;
   background: rgba(248, 113, 113, 0.16);


### PR DESCRIPTION
## Summary
- add scenario orchestration service to cover care coordination, sms outreach, intake, monitoring, alerts, population health, and post-discharge flows
- wire new notifications helpers and error handling into the API along with updated OpenAPI + docs

## Testing
- npm -w server run test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68e62b8198688331917a798227480b75