### PR TITLE
Add care coordination call workflow

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,10 +6,12 @@ import evidence from './routes/evidence';
 import ai from './routes/ai';
 import scenarios from './routes/scenarios';
 import detections from './routes/detections';
+import calls from './routes/calls';
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 app.get('/api/health', (_req, res) => res.json({ ok: true }));
 
@@ -19,6 +21,7 @@ app.use('/api/evidence', evidence);
 app.use('/api/ai', ai);
 app.use('/api/scenarios', scenarios);
 app.use('/api/ai/detections', detections);
+app.use('/api/calls', calls);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, jsonb, timestamp } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, jsonb, timestamp, integer } from 'drizzle-orm/pg-core';
 
 export const tenants = pgTable('tenants', {
   id: uuid('id').primaryKey(),
@@ -103,5 +103,48 @@ export const aiDetections = pgTable('ai_detections', {
   narrative: text('narrative'),
   revenue: jsonb('revenue'),
   compliance: jsonb('compliance'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});
+
+export const calls = pgTable('calls', {
+  id: uuid('id').primaryKey(),
+  tenantId: uuid('tenant_id').notNull().references(() => tenants.id),
+  memberId: uuid('member_id').notNull().references(() => members.id),
+  direction: text('direction').notNull().default('outbound'),
+  fromNumber: text('from_number'),
+  toNumber: text('to_number'),
+  status: text('status').notNull().default('initiated'),
+  twilioCallSid: text('twilio_call_sid'),
+  metadata: jsonb('metadata'),
+  startedAt: timestamp('started_at', { withTimezone: true }).defaultNow(),
+  endedAt: timestamp('ended_at', { withTimezone: true }),
+  durationSeconds: integer('duration_seconds'),
+  summaryEmailSentAt: timestamp('summary_email_sent_at', { withTimezone: true }),
+  lastDetectionId: uuid('last_detection_id'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+});
+
+export const callTranscripts = pgTable('call_transcripts', {
+  id: uuid('id').primaryKey(),
+  callId: uuid('call_id')
+    .notNull()
+    .references(() => calls.id, { onDelete: 'cascade' }),
+  messages: jsonb('messages').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+});
+
+export const callDetections = pgTable('call_detections', {
+  id: uuid('id').primaryKey(),
+  callId: uuid('call_id')
+    .notNull()
+    .references(() => calls.id, { onDelete: 'cascade' }),
+  engine: text('engine'),
+  issues: jsonb('issues').notNull(),
+  documentation: jsonb('documentation'),
+  revenue: jsonb('revenue'),
+  compliance: jsonb('compliance'),
+  narrative: text('narrative'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 });

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import pg from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { tenants, users, members, consents } from './schema';
+import { tenants, users, members, consents, calls, callTranscripts } from './schema';
 import { env } from '../env';
 
 (async () => {
@@ -15,6 +15,71 @@ import { env } from '../env';
   await db.insert(members).values({ id: memberId, tenantId, firstName: 'Alex', lastName: 'Rivera', dob: '1952-03-14' });
   const consentId = randomUUID();
   await db.insert(consents).values({ id: consentId, tenantId, memberId, scope: 'sdoh_evidence', source: 'verbal', evidence: { agent: 'staff-1' } });
+
+  const callId = randomUUID();
+  const callStarted = new Date('2025-01-17T15:03:00Z');
+  const callEnded = new Date('2025-01-17T15:05:30Z');
+  const transcriptSample = [
+    {
+      speaker: 'navigator',
+      text: 'Hola Alex, thanks for picking up. We are checking in about groceries and your SNAP renewal.',
+      language: 'es',
+      timestamp: '2025-01-17T15:03:00Z',
+    },
+    {
+      speaker: 'member',
+      text: 'Yeah it has been rough. The food bank is the only place I eat lately and sometimes they close early.',
+      language: 'en',
+      timestamp: '2025-01-17T15:03:27Z',
+    },
+    {
+      speaker: 'member',
+      text: 'Mi nevera está vacía casi siempre y me salto comidas.',
+      language: 'es',
+      timestamp: '2025-01-17T15:03:48Z',
+    },
+    {
+      speaker: 'navigator',
+      text: 'We can escalate the emergency pantry delivery. Did the utility company restore your electricity yet?',
+      language: 'en',
+      timestamp: '2025-01-17T15:04:03Z',
+    },
+    {
+      speaker: 'member',
+      text: 'No, my electricity got shut off on Tuesday and they said it might take a week unless I pay everything.',
+      language: 'en',
+      timestamp: '2025-01-17T15:04:18Z',
+    },
+  ];
+
+  await db
+    .insert(calls)
+    .values({
+      id: callId,
+      tenantId,
+      memberId,
+      direction: 'outbound',
+      fromNumber: '+18005550100',
+      toNumber: '+15555551212',
+      status: 'completed',
+      startedAt: callStarted,
+      endedAt: callEnded,
+      durationSeconds: Math.floor((callEnded.getTime() - callStarted.getTime()) / 1000),
+      metadata: { seed: true },
+    })
+    .onConflictDoNothing();
+
+  await db
+    .insert(callTranscripts)
+    .values({
+      id: randomUUID(),
+      callId,
+      messages: transcriptSample as any,
+      createdAt: callStarted,
+      updatedAt: callEnded,
+    })
+    .onConflictDoNothing();
+
   console.log({ tenantId, userId, memberId, consentId });
   process.exit(0);
 })();

--- a/server/src/routes/calls.ts
+++ b/server/src/routes/calls.ts
@@ -1,0 +1,654 @@
+import { Router } from 'express';
+import { randomUUID } from 'crypto';
+import { z } from 'zod';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { db } from '../util/db';
+import {
+  calls,
+  callTranscripts,
+  callDetections,
+  members,
+} from '../db/schema';
+import { env } from '../env';
+import { initiateVoiceCall } from '../services/voice';
+import { detectConversation } from '../services/sdohEngine';
+import { sendEmail } from '../services/notifications';
+
+const router = Router();
+
+const transcriptMessageSchema = z.object({
+  speaker: z.string(),
+  text: z.string(),
+  language: z.string().optional(),
+  timestamp: z.string().optional(),
+});
+
+const createCallSchema = z.object({
+  memberId: z.string(),
+  to: z.string(),
+  from: z.string().optional(),
+  direction: z.enum(['outbound', 'inbound']).default('outbound'),
+  metadata: z.record(z.unknown()).optional(),
+  transcript: z.array(transcriptMessageSchema).optional(),
+  startedAt: z.string().optional(),
+  endedAt: z.string().optional(),
+  durationSeconds: z.number().int().positive().optional(),
+});
+
+const appendTranscriptSchema = z.object({
+  segments: z.array(transcriptMessageSchema).nonempty(),
+  replace: z.boolean().default(false).optional(),
+});
+
+const detectionRunSchema = z.object({
+  context: z.record(z.unknown()).optional(),
+});
+
+const sendSummarySchema = z.object({
+  to: z.array(z.string().email()).nonempty(),
+  detectionId: z.string().optional(),
+  subject: z.string().optional(),
+  intro: z.string().optional(),
+});
+
+type TranscriptMessage = z.infer<typeof transcriptMessageSchema>;
+
+type DetectionRecord = {
+  id: string;
+  engine?: string | null;
+  issues: TranscriptIssue[];
+  documentation?: Record<string, unknown> | null;
+  revenue?: Record<string, unknown> | null;
+  compliance?: Record<string, unknown> | null;
+  narrative?: string | null;
+  createdAt: string;
+};
+
+type TranscriptIssue = {
+  code: string;
+  label: string;
+  domain?: string;
+  severity: string;
+  urgency: string;
+  status?: string;
+  confidence: number;
+  rationale?: string;
+  evidence?: TranscriptMessage[];
+};
+
+type CallRow = typeof calls.$inferSelect;
+
+type CallSummary = {
+  id: string;
+  memberId: string;
+  memberName?: string | null;
+  direction: string;
+  fromNumber?: string | null;
+  toNumber?: string | null;
+  status: string;
+  startedAt?: string | null;
+  endedAt?: string | null;
+  durationSeconds?: number | null;
+  transcriptMessageCount: number;
+  lastDetection?: Pick<DetectionRecord, 'id' | 'createdAt'> & { issueCount: number } | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+};
+
+function parseTranscriptMessages(value: unknown): TranscriptMessage[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      const parsed = transcriptMessageSchema.safeParse(item);
+      return parsed.success ? parsed.data : null;
+    })
+    .filter((msg): msg is TranscriptMessage => msg !== null);
+}
+
+function serializeCall(row: CallRow, memberName?: string | null, transcriptCount = 0, lastDetection?: DetectionRecord | null): CallSummary {
+  return {
+    id: row.id,
+    memberId: row.memberId,
+    memberName: memberName ?? null,
+    direction: row.direction,
+    fromNumber: row.fromNumber,
+    toNumber: row.toNumber,
+    status: row.status,
+    startedAt: row.startedAt?.toISOString?.() ?? null,
+    endedAt: row.endedAt?.toISOString?.() ?? null,
+    durationSeconds: row.durationSeconds ?? null,
+    transcriptMessageCount: transcriptCount,
+    lastDetection: lastDetection
+      ? { id: lastDetection.id, createdAt: lastDetection.createdAt, issueCount: lastDetection.issues.length }
+      : null,
+    createdAt: row.createdAt?.toISOString?.() ?? null,
+    updatedAt: row.updatedAt?.toISOString?.() ?? null,
+  };
+}
+
+async function fetchCallDetail(callId: string) {
+  const rows = await db
+    .select()
+    .from(calls)
+    .leftJoin(members, eq(members.id, calls.memberId))
+    .where(and(eq(calls.id, callId), eq(calls.tenantId, env.TENANT_ID)));
+
+  const row = rows[0];
+  if (!row) return null;
+
+  const transcriptRows = await db
+    .select()
+    .from(callTranscripts)
+    .where(eq(callTranscripts.callId, callId))
+    .orderBy(desc(callTranscripts.updatedAt))
+    .limit(1);
+
+  const detectionRows = await db
+    .select()
+    .from(callDetections)
+    .where(eq(callDetections.callId, callId))
+    .orderBy(desc(callDetections.createdAt));
+
+  const transcriptMessages = parseTranscriptMessages(transcriptRows[0]?.messages);
+  const detections: DetectionRecord[] = detectionRows.map((det) => ({
+    id: det.id,
+    engine: det.engine,
+    issues: parseDetectionIssues(det.issues),
+    documentation: det.documentation as Record<string, unknown> | null,
+    revenue: det.revenue as Record<string, unknown> | null,
+    compliance: det.compliance as Record<string, unknown> | null,
+    narrative: det.narrative,
+    createdAt: det.createdAt?.toISOString?.() ?? new Date().toISOString(),
+  }));
+
+  return {
+    call: serializeCall(row.calls, formatMemberName(row.members), transcriptMessages.length, detections[0] ?? null),
+    transcript: {
+      messages: transcriptMessages,
+      updatedAt: transcriptRows[0]?.updatedAt?.toISOString?.() ?? null,
+    },
+    detections,
+    metadata: row.calls.metadata as Record<string, unknown> | null,
+  };
+}
+
+function parseDetectionIssues(value: unknown): TranscriptIssue[] {
+  if (!Array.isArray(value)) return [];
+  const issues: TranscriptIssue[] = [];
+  for (const item of value) {
+    if (typeof item !== 'object' || !item) continue;
+    const base = item as Record<string, unknown>;
+    if (
+      typeof base.code !== 'string' ||
+      typeof base.label !== 'string' ||
+      typeof base.severity !== 'string' ||
+      typeof base.urgency !== 'string'
+    ) {
+      continue;
+    }
+    issues.push({
+      code: base.code,
+      label: base.label,
+      domain: typeof base.domain === 'string' ? base.domain : undefined,
+      severity: base.severity,
+      urgency: base.urgency,
+      status: typeof base.status === 'string' ? base.status : undefined,
+      confidence: typeof base.confidence === 'number' ? base.confidence : Number(base.confidence) || 0,
+      rationale: typeof base.rationale === 'string' ? base.rationale : undefined,
+      evidence: parseTranscriptMessages(base.evidence),
+    });
+  }
+  return issues;
+}
+
+function formatMemberName(member: typeof members.$inferSelect | null): string | null {
+  if (!member) return null;
+  const parts = [member.firstName, member.lastName].filter(Boolean);
+  return parts.join(' ') || null;
+}
+
+router.post('/', async (req, res, next) => {
+  try {
+    const body = createCallSchema.parse(req.body);
+    const id = randomUUID();
+    const now = new Date();
+    const fromNumber = body.from || process.env.TWILIO_FROM_NUMBER || null;
+
+    await db.insert(calls).values({
+      id,
+      tenantId: env.TENANT_ID,
+      memberId: body.memberId,
+      direction: body.direction,
+      fromNumber,
+      toNumber: body.to,
+      status: 'initiated',
+      metadata: body.metadata as any,
+      startedAt: body.startedAt ? new Date(body.startedAt) : now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    if (body.transcript?.length) {
+      await db.insert(callTranscripts).values({
+        id: randomUUID(),
+        callId: id,
+        messages: body.transcript as any,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    const baseUrl =
+      process.env.VOICE_WEBHOOK_BASE_URL || `${req.protocol}://${req.get('host')}`;
+    const twimlUrl = `${baseUrl}/api/calls/${id}/twiml`;
+    const statusUrl = `${baseUrl}/api/calls/${id}/status`;
+
+    const voiceResult = await initiateVoiceCall({
+      to: body.to,
+      from: fromNumber,
+      twimlUrl,
+      statusCallbackUrl: statusUrl,
+    });
+
+    const updates: Partial<CallRow> = {
+      status: voiceResult.status || (voiceResult.sid ? 'initiated' : 'completed'),
+      updatedAt: new Date(),
+    };
+
+    if (voiceResult.sid) {
+      updates.twilioCallSid = voiceResult.sid;
+    }
+
+    if (!voiceResult.sid && body.transcript?.length) {
+      const end = body.endedAt ? new Date(body.endedAt) : new Date();
+      updates.endedAt = end;
+      updates.durationSeconds = body.durationSeconds ?? Math.max(1, body.transcript.length * 8);
+    }
+
+    if (body.durationSeconds && !updates.durationSeconds) {
+      updates.durationSeconds = body.durationSeconds;
+    }
+
+    if (body.endedAt && !updates.endedAt) {
+      updates.endedAt = new Date(body.endedAt);
+    }
+
+    await db.update(calls).set(updates as any).where(eq(calls.id, id));
+
+    const detail = await fetchCallDetail(id);
+    res.json({
+      call: detail?.call,
+      transcript: detail?.transcript,
+      detections: detail?.detections ?? [],
+      voice: voiceResult,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const limit = Math.min(100, Math.max(1, Number(req.query.limit) || 25));
+    const rows = await db
+      .select()
+      .from(calls)
+      .leftJoin(members, eq(members.id, calls.memberId))
+      .where(eq(calls.tenantId, env.TENANT_ID))
+      .orderBy(desc(calls.startedAt))
+      .limit(limit);
+
+    const callIds = rows.map((row) => row.calls.id);
+    let transcriptsMap = new Map<string, TranscriptMessage[]>();
+    if (callIds.length) {
+      const transcriptRows = await db
+        .select()
+        .from(callTranscripts)
+        .where(inArray(callTranscripts.callId, callIds));
+      transcriptsMap = new Map(
+        transcriptRows.map((row) => [row.callId, parseTranscriptMessages(row.messages)])
+      );
+    }
+
+    let lastDetectionMap = new Map<string, DetectionRecord>();
+    if (callIds.length) {
+      const detectionRows = await db
+        .select()
+        .from(callDetections)
+        .where(inArray(callDetections.callId, callIds))
+        .orderBy(desc(callDetections.createdAt));
+
+      for (const det of detectionRows) {
+        if (!lastDetectionMap.has(det.callId)) {
+          lastDetectionMap.set(det.callId, {
+            id: det.id,
+            engine: det.engine,
+            issues: parseDetectionIssues(det.issues),
+            documentation: det.documentation as Record<string, unknown> | null,
+            revenue: det.revenue as Record<string, unknown> | null,
+            compliance: det.compliance as Record<string, unknown> | null,
+            narrative: det.narrative,
+            createdAt: det.createdAt?.toISOString?.() ?? new Date().toISOString(),
+          });
+        }
+      }
+    }
+
+    const payload: CallSummary[] = rows.map((row) =>
+      serializeCall(
+        row.calls,
+        formatMemberName(row.members),
+        transcriptsMap.get(row.calls.id)?.length ?? 0,
+        lastDetectionMap.get(row.calls.id) ?? null
+      )
+    );
+
+    res.json({ calls: payload });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const detail = await fetchCallDetail(req.params.id);
+    if (!detail) {
+      res.status(404).json({ error: 'Call not found' });
+      return;
+    }
+
+    res.json(detail);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/:id/transcript', async (req, res, next) => {
+  try {
+    const body = appendTranscriptSchema.parse(req.body);
+    const detail = await fetchCallDetail(req.params.id);
+    if (!detail) {
+      res.status(404).json({ error: 'Call not found' });
+      return;
+    }
+
+    const existingMessages = body.replace
+      ? []
+      : detail.transcript?.messages ?? [];
+    const updatedMessages = [...existingMessages, ...body.segments];
+
+    const now = new Date();
+    if (detail.transcript?.messages?.length) {
+      await db
+        .update(callTranscripts)
+        .set({ messages: updatedMessages as any, updatedAt: now })
+        .where(eq(callTranscripts.callId, req.params.id));
+    } else {
+      await db.insert(callTranscripts).values({
+        id: randomUUID(),
+        callId: req.params.id,
+        messages: updatedMessages as any,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    await db
+      .update(calls)
+      .set({ updatedAt: now })
+      .where(eq(calls.id, req.params.id));
+
+    res.json({ ok: true, messages: updatedMessages });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/:id/status', async (req, res, next) => {
+  try {
+    const detail = await fetchCallDetail(req.params.id);
+    if (!detail) {
+      res.status(404).json({ error: 'Call not found' });
+      return;
+    }
+
+    const status = typeof req.body.CallStatus === 'string' ? req.body.CallStatus : req.body.status;
+    const durationRaw = req.body.CallDuration || req.body.durationSeconds;
+    const durationSeconds = typeof durationRaw === 'string' ? Number(durationRaw) : Number(durationRaw || 0);
+    const now = new Date();
+
+    const updates: Partial<CallRow> = {
+      status: status || detail.call.status,
+      updatedAt: now,
+    };
+
+    if (!detail.call.startedAt && (status === 'in-progress' || status === 'answered')) {
+      updates.startedAt = now;
+    }
+
+    if (['completed', 'canceled', 'failed', 'busy', 'no-answer'].includes(String(status || '').toLowerCase())) {
+      updates.endedAt = now;
+      if (!Number.isNaN(durationSeconds) && durationSeconds > 0) {
+        updates.durationSeconds = durationSeconds;
+      } else if (detail.call.startedAt) {
+        const start = new Date(detail.call.startedAt);
+        updates.durationSeconds = Math.max(0, Math.round((now.getTime() - start.getTime()) / 1000));
+      }
+    } else if (!Number.isNaN(durationSeconds) && durationSeconds > 0) {
+      updates.durationSeconds = durationSeconds;
+    }
+
+    await db.update(calls).set(updates as any).where(eq(calls.id, req.params.id));
+
+    res.json({ ok: true, status: updates.status });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/:id/run-detection', async (req, res, next) => {
+  try {
+    const detail = await fetchCallDetail(req.params.id);
+    if (!detail) {
+      res.status(404).json({ error: 'Call not found' });
+      return;
+    }
+
+    if (!detail.transcript?.messages?.length) {
+      res.status(400).json({ error: 'No transcript available for detection' });
+      return;
+    }
+
+    const body = detectionRunSchema.parse(req.body || {});
+    const detection = await detectConversation({
+      memberId: detail.call.memberId,
+      transcript: detail.transcript.messages,
+      context: body.context ?? undefined,
+    });
+
+    const detectionId = randomUUID();
+    const now = new Date();
+
+    await db.insert(callDetections).values({
+      id: detectionId,
+      callId: detail.call.id,
+      engine: detection.engine,
+      issues: detection.issues as any,
+      documentation: detection.documentation as any,
+      revenue: detection.revenue as any,
+      compliance: detection.compliance as any,
+      narrative: detection.documentation?.narrative,
+      createdAt: now,
+    });
+
+    await db
+      .update(calls)
+      .set({ lastDetectionId: detectionId, updatedAt: now })
+      .where(eq(calls.id, detail.call.id));
+
+    res.json({ detectionId, detection });
+  } catch (error) {
+    next(error);
+  }
+});
+
+function buildIssuesTable(issues: TranscriptIssue[]): { text: string; html: string } {
+  if (!issues.length) {
+    const message = 'No active SDOH risks detected.';
+    return { text: message, html: `<p><strong>${message}</strong></p>` };
+  }
+
+  const text = issues
+    .map(
+      (issue) =>
+        `${issue.label} (${issue.code}) — severity ${issue.severity}, urgency ${issue.urgency}, confidence ${Math.round(issue.confidence * 100) / 100}`
+    )
+    .join('\n');
+
+  const rows = issues
+    .map(
+      (issue) =>
+        `<tr><td>${issue.code}</td><td>${issue.label}</td><td>${issue.severity}</td><td>${issue.urgency}</td><td>${issue.confidence.toFixed(2)}</td></tr>`
+    )
+    .join('');
+
+  const html = `
+    <table border="1" cellpadding="6" cellspacing="0">
+      <thead>
+        <tr>
+          <th>Code</th>
+          <th>Description</th>
+          <th>Severity</th>
+          <th>Urgency</th>
+          <th>Confidence</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+
+  return { text, html };
+}
+
+router.post('/:id/send-summary', async (req, res, next) => {
+  try {
+    const detail = await fetchCallDetail(req.params.id);
+    if (!detail) {
+      res.status(404).json({ error: 'Call not found' });
+      return;
+    }
+
+    const body = sendSummarySchema.parse(req.body);
+
+    const detection =
+      (body.detectionId
+        ? detail.detections.find((det) => det.id === body.detectionId)
+        : detail.detections[0]) ?? null;
+
+    if (!detection) {
+      res.status(400).json({ error: 'No detection results available' });
+      return;
+    }
+
+    const { text, html } = buildIssuesTable(detection.issues);
+    const narrative = detection.narrative ?? detection.documentation?.narrative;
+    const revenue = detection.revenue && typeof detection.revenue.potentialRevenue === 'number'
+      ? (detection.revenue.potentialRevenue as number)
+      : undefined;
+    const compliance = detection.compliance && typeof detection.compliance.completionRate === 'number'
+      ? (detection.compliance.completionRate as number)
+      : undefined;
+    const alerts = Array.isArray(detection.compliance?.alerts)
+      ? (detection.compliance?.alerts as { message?: string }[])
+          .map((alert) => alert?.message)
+          .filter((msg): msg is string => Boolean(msg))
+      : [];
+
+    const narrativeText = narrative ? `Narrative Summary:\n${narrative}\n\n` : '';
+    const revenueText = typeof revenue === 'number' ? `Potential Revenue Impact: $${revenue.toLocaleString()}\n` : '';
+    const complianceText = typeof compliance === 'number' ? `Compliance Completion Rate: ${Math.round(compliance * 100) / 100}%\n` : '';
+    const alertsText = alerts.length ? `Alerts:\n${alerts.map((alert) => `• ${alert}`).join('\n')}\n\n` : '';
+
+    const emailText = `${body.intro ? `${body.intro}\n\n` : ''}${narrativeText}${revenueText}${complianceText}${alertsText}${text}`.trim();
+    const emailHtml = `
+      <div>
+        ${body.intro ? `<p>${body.intro}</p>` : ''}
+        ${narrative ? `<p><strong>Narrative Summary</strong><br/>${narrative}</p>` : ''}
+        ${typeof revenue === 'number' ? `<p><strong>Potential Revenue Impact:</strong> $${revenue.toLocaleString()}</p>` : ''}
+        ${typeof compliance === 'number' ? `<p><strong>Compliance Completion Rate:</strong> ${compliance}%</p>` : ''}
+        ${alerts.length ? `<ul>${alerts.map((alert) => `<li>${alert}</li>`).join('')}</ul>` : ''}
+        ${html}
+      </div>
+    `;
+
+    const subject =
+      body.subject ||
+      `SDOH Call Summary • ${detail.call.memberName ?? detail.call.memberId} • ${new Date().toLocaleDateString()}`;
+
+    const result = await sendEmail({
+      to: body.to,
+      subject,
+      text: emailText,
+      html: emailHtml,
+      categories: ['sdoh-call-summary'],
+      customArgs: {
+        callId: detail.call.id,
+        memberId: detail.call.memberId,
+      },
+    });
+
+    const now = new Date();
+    await db
+      .update(calls)
+      .set({ summaryEmailSentAt: now, updatedAt: now })
+      .where(eq(calls.id, detail.call.id));
+
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+router.all('/:id/twiml', async (req, res, next) => {
+  try {
+    const detail = await fetchCallDetail(req.params.id);
+    if (!detail) {
+      res.status(404).type('text/xml').send('<Response><Say>Call not found.</Say></Response>');
+      return;
+    }
+
+    const greeting = process.env.TWILIO_CONNECT_GREETING || 'Connecting your Care Coordination call.';
+    const streamBase = process.env.TWILIO_STREAM_WEBSOCKET_URL;
+    const fromNumber = detail.call.fromNumber || process.env.TWILIO_FROM_NUMBER || '';
+
+    const streamTag = streamBase
+      ? `<Start><Stream url="${escapeXml(streamBase.replace('{CALL_ID}', detail.call.id))}" track="both_tracks" /></Start>`
+      : '';
+
+    const dialTarget = detail.call.toNumber
+      ? `<Dial callerId="${escapeXml(fromNumber)}">${escapeXml(detail.call.toNumber)}</Dial>`
+      : '<Pause length="5" />';
+
+    const response = `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say>${escapeXml(greeting)}</Say>
+  ${streamTag}
+  ${dialTarget}
+</Response>`;
+
+    res.type('text/xml').send(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/services/voice.ts
+++ b/server/src/services/voice.ts
@@ -1,0 +1,82 @@
+import { URLSearchParams } from 'url';
+
+type VoiceCallRequest = {
+  to: string;
+  from?: string | null;
+  twimlUrl: string;
+  statusCallbackUrl?: string;
+  machineDetection?: 'Enable' | 'DetectMessageEnd';
+};
+
+type VoiceCallResult = {
+  sid?: string;
+  status?: string;
+  accountSid?: string;
+  preview?: {
+    to: string;
+    from?: string | null;
+    twimlUrl: string;
+    statusCallbackUrl?: string;
+  };
+  error?: string;
+};
+
+function missingCredentials(): boolean {
+  return !process.env.TWILIO_ACCOUNT_SID || !process.env.TWILIO_AUTH_TOKEN;
+}
+
+export async function initiateVoiceCall(params: VoiceCallRequest): Promise<VoiceCallResult> {
+  const from = params.from || process.env.TWILIO_FROM_NUMBER || null;
+  if (missingCredentials() || !from) {
+    const preview = {
+      to: params.to,
+      from,
+      twimlUrl: params.twimlUrl,
+      statusCallbackUrl: params.statusCallbackUrl,
+    };
+    console.info('[voice] Twilio credentials missing – returning preview', preview);
+    return { preview };
+  }
+
+  const accountSid = process.env.TWILIO_ACCOUNT_SID as string;
+  const authToken = process.env.TWILIO_AUTH_TOKEN as string;
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls.json`;
+
+  const payload = new URLSearchParams({
+    To: params.to,
+    From: from,
+    Url: params.twimlUrl,
+  });
+
+  if (params.statusCallbackUrl) {
+    payload.append('StatusCallback', params.statusCallbackUrl);
+    payload.append('StatusCallbackMethod', 'POST');
+    payload.append('StatusCallbackEvent', 'initiated ringing answered completed');
+  }
+
+  if (params.machineDetection) {
+    payload.append('MachineDetection', params.machineDetection);
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${accountSid}:${authToken}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: payload.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('[voice] Twilio API error', response.status, errorText);
+    return { error: `Twilio request failed: ${errorText}` };
+  }
+
+  const data = (await response.json()) as { sid?: string; status?: string; account_sid?: string };
+  return {
+    sid: data.sid,
+    status: data.status,
+    accountSid: data.account_sid,
+  };
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import Member from './pages/Member';
 import ScenariosDashboard from './pages/ScenariosDashboard';
+import CallsDashboard from './pages/CallsDashboard';
 
 function usePathname() {
   const [path, setPath] = useState(() => window.location.pathname);
@@ -17,9 +18,46 @@ function usePathname() {
 export default function App() {
   const path = usePathname();
 
-  if (path.startsWith('/scenarios')) {
-    return <ScenariosDashboard />;
+  function navigate(target: string) {
+    if (target === path) return;
+    window.history.pushState({}, '', target);
+    window.dispatchEvent(new PopStateEvent('popstate'));
   }
 
-  return <Member />;
+  const navItems = [
+    { label: 'Member 360', path: '/' },
+    { label: 'Care Calls', path: '/calls' },
+    { label: 'AI Scenarios', path: '/scenarios' },
+  ];
+
+  let page: JSX.Element = <Member />;
+  if (path.startsWith('/calls')) {
+    page = <CallsDashboard />;
+  } else if (path.startsWith('/scenarios')) {
+    page = <ScenariosDashboard />;
+  }
+
+  return (
+    <div className="app-container">
+      <header className="app-header">
+        <div className="app-header__brand">
+          <span className="app-header__logo">SDOH Bridge</span>
+          <span className="app-header__subtitle">Care Coordination Ops</span>
+        </div>
+        <nav className="app-nav">
+          {navItems.map((item) => (
+            <button
+              key={item.path}
+              type="button"
+              className={`app-nav__item${path === item.path || path.startsWith(item.path) ? ' app-nav__item--active' : ''}`}
+              onClick={() => navigate(item.path)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+      </header>
+      <main className="app-main">{page}</main>
+    </div>
+  );
 }

--- a/web/src/data/transcripts.ts
+++ b/web/src/data/transcripts.ts
@@ -1,0 +1,96 @@
+export type TranscriptMessage = {
+  speaker: string;
+  text: string;
+  language?: string;
+  timestamp?: string;
+};
+
+export type TranscriptSample = {
+  id: string;
+  title: string;
+  summary: string;
+  transcript: TranscriptMessage[];
+};
+
+export const transcriptSamples: TranscriptSample[] = [
+  {
+    id: 'alex-rivera',
+    title: 'Alex Rivera | Food + Utilities',
+    summary: 'Bilingual outreach call covering food access, SNAP renewal, and power shutoff risk.',
+    transcript: [
+      {
+        speaker: 'navigator',
+        text: 'Hola Alex, thanks for picking up. We are checking in about groceries and your SNAP renewal.',
+        language: 'es',
+        timestamp: '2025-01-17T15:03:00Z',
+      },
+      {
+        speaker: 'member',
+        text: 'Yeah it has been rough. The food bank is the only place I eat lately and sometimes they close early.',
+        language: 'en',
+        timestamp: '2025-01-17T15:03:27Z',
+      },
+      {
+        speaker: 'member',
+        text: 'Mi nevera está vacía casi siempre y me salto comidas.',
+        language: 'es',
+        timestamp: '2025-01-17T15:03:48Z',
+      },
+      {
+        speaker: 'navigator',
+        text: 'We can escalate the emergency pantry delivery. Did the utility company restore your electricity yet?',
+        language: 'en',
+        timestamp: '2025-01-17T15:04:03Z',
+      },
+      {
+        speaker: 'member',
+        text: 'No, my electricity got shut off on Tuesday and they said it might take a week unless I pay everything.',
+        language: 'en',
+        timestamp: '2025-01-17T15:04:18Z',
+      },
+      {
+        speaker: 'member',
+        text: 'Estoy durmiendo en mi coche por las noches para mantenerme caliente.',
+        language: 'es',
+        timestamp: '2025-01-17T15:04:39Z',
+      },
+      {
+        speaker: 'navigator',
+        text: 'That is not safe. We will activate utility relief and emergency housing supports right now.',
+        language: 'en',
+        timestamp: '2025-01-17T15:04:55Z',
+      },
+    ],
+  },
+  {
+    id: 'maria-lopez',
+    title: 'María López | Transportation + Meds',
+    summary: 'SMS follow-up about transportation barriers and medication affordability.',
+    transcript: [
+      {
+        speaker: 'member',
+        text: 'My landlord is evicting me next month so I am packing up.',
+        language: 'en',
+        timestamp: '2025-01-12T19:12:45Z',
+      },
+      {
+        speaker: 'member',
+        text: 'No tengo coche ahora, el motor murió y no tengo transporte para llegar a la clínica.',
+        language: 'es',
+        timestamp: '2025-01-12T19:13:10Z',
+      },
+      {
+        speaker: 'member',
+        text: "I can't afford my medications until next paycheck. Maybe in two weeks.",
+        language: 'en',
+        timestamp: '2025-01-12T19:13:54Z',
+      },
+      {
+        speaker: 'nurse',
+        text: 'Thanks María, logging this for the care team. We will set up mail-order meds and a Lyft voucher.',
+        language: 'en',
+        timestamp: '2025-01-12T19:14:11Z',
+      },
+    ],
+  },
+];

--- a/web/src/pages/CallsDashboard.tsx
+++ b/web/src/pages/CallsDashboard.tsx
@@ -1,0 +1,499 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import {
+  api,
+  type CallSummary,
+  type CallDetail,
+  type CallDetectionRecord,
+  type DetectionResponse,
+} from '../api';
+import { transcriptSamples } from '../data/transcripts';
+
+const MEMBER_ID = 'demo-member';
+const DEFAULT_TO_NUMBER = '+15555551212';
+const DEFAULT_FROM_NUMBER = '+18005550100';
+
+function formatDateTime(value?: string | null) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+function formatDuration(seconds?: number | null) {
+  if (!seconds || seconds <= 0) return '—';
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (mins === 0) return `${secs}s`;
+  return `${mins}m ${secs.toString().padStart(2, '0')}s`;
+}
+
+function normalizeStatus(status: string) {
+  return status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function convertStoredDetection(record?: CallDetectionRecord | null): DetectionResponse | null {
+  if (!record) return null;
+  const structuredIssues = (record.issues ?? []).map((issue) => ({
+    code: issue.code,
+    label: issue.label,
+    severity: issue.severity,
+    urgency: issue.urgency,
+    status: (issue.status as 'current' | 'resolved' | 'historical') || 'current',
+    confidence: issue.confidence ?? 0,
+    evidenceCount: issue.evidence?.length ?? 0,
+  }));
+
+  const fallbackDocumentation = {
+    structured: {
+      detectedAt: record.createdAt,
+      issues: structuredIssues,
+      languages: [],
+    },
+    narrative: record.narrative ?? '',
+    recommendedCodes: [],
+    evidence: record.issues?.flatMap((issue) => issue.evidence ?? []) ?? [],
+  } as DetectionResponse['documentation'];
+
+  const fallbackRevenue = {
+    potentialRevenue: 0,
+    zCodesGenerated: 0,
+    patientsScreened: 0,
+    patientsRequired: 0,
+    riskAdjustmentImpact: 0,
+    prevalenceTrends: [],
+    accuracyEstimate: 0,
+    latencyEstimateMs: 0,
+  } satisfies DetectionResponse['revenue'];
+
+  const fallbackCompliance = {
+    needsScreening: false,
+    nextDueDate: record.createdAt,
+    completionRate: 0,
+    cmsReport: [],
+    alerts: [],
+  } satisfies DetectionResponse['compliance'];
+
+  return {
+    engine: (record.engine as DetectionResponse['engine']) || 'gpt-orchestrator',
+    issues: record.issues ?? [],
+    documentation: (record.documentation as DetectionResponse['documentation']) ?? fallbackDocumentation,
+    revenue: (record.revenue as DetectionResponse['revenue']) ?? fallbackRevenue,
+    compliance: (record.compliance as DetectionResponse['compliance']) ?? fallbackCompliance,
+    debug: record.engine ? { fallbackUsed: false, model: record.engine } : undefined,
+  };
+}
+
+export default function CallsDashboard() {
+  const [callList, setCallList] = useState<CallSummary[]>([]);
+  const [selectedCallId, setSelectedCallId] = useState<string | null>(null);
+  const [selectedCall, setSelectedCall] = useState<CallDetail | null>(null);
+  const [listLoading, setListLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  const [callForm, setCallForm] = useState({
+    to: DEFAULT_TO_NUMBER,
+    from: DEFAULT_FROM_NUMBER,
+    sampleId: transcriptSamples[0]?.id ?? '',
+  });
+  const [callSubmitting, setCallSubmitting] = useState(false);
+  const [callSuccess, setCallSuccess] = useState<string | null>(null);
+  const [callSubmitError, setCallSubmitError] = useState<string | null>(null);
+
+  const [activeDetection, setActiveDetection] = useState<DetectionResponse | null>(null);
+  const [detectionLoading, setDetectionLoading] = useState(false);
+  const [detectionError, setDetectionError] = useState<string | null>(null);
+
+  const [summaryRecipients, setSummaryRecipients] = useState('careteam@example.com');
+  const [summaryIntro, setSummaryIntro] = useState('');
+  const [summaryStatus, setSummaryStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+  const [summaryError, setSummaryError] = useState<string | null>(null);
+
+  async function loadCalls(options?: { focusId?: string }) {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const data = await api.listCalls();
+      setCallList(data.calls);
+      if (options?.focusId) {
+        await loadCallDetail(options.focusId);
+      } else if (!selectedCallId && data.calls[0]) {
+        await loadCallDetail(data.calls[0].id);
+      } else if (selectedCallId) {
+        const exists = data.calls.some((call) => call.id === selectedCallId);
+        if (!exists && data.calls[0]) {
+          await loadCallDetail(data.calls[0].id);
+        }
+      }
+    } catch (error) {
+      console.error(error);
+      setListError('Unable to load call history.');
+    } finally {
+      setListLoading(false);
+    }
+  }
+
+  async function loadCallDetail(id: string) {
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      const detail = await api.getCall(id);
+      setSelectedCallId(id);
+      setSelectedCall(detail);
+      setActiveDetection(null);
+    } catch (error) {
+      console.error(error);
+      setDetailError('Unable to load call detail.');
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadCalls().catch((err) => console.error(err));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const detectionToDisplay = useMemo(() => {
+    if (activeDetection) return activeDetection;
+    return convertStoredDetection(selectedCall?.detections?.[0]);
+  }, [activeDetection, selectedCall]);
+
+  async function handleCreateCall(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!callForm.sampleId) {
+      setCallSubmitError('Select a transcript sample to simulate transcription.');
+      return;
+    }
+    const sample = transcriptSamples.find((item) => item.id === callForm.sampleId);
+    if (!sample) {
+      setCallSubmitError('Transcript sample not found.');
+      return;
+    }
+
+    setCallSubmitting(true);
+    setCallSubmitError(null);
+    setCallSuccess(null);
+    try {
+      const response = await api.createCall({
+        memberId: MEMBER_ID,
+        to: callForm.to,
+        from: callForm.from || undefined,
+        direction: 'outbound',
+        metadata: { sampleId: sample.id, sampleTitle: sample.title },
+        transcript: sample.transcript,
+      });
+
+      if (!response.call?.id) {
+        throw new Error('Call creation failed');
+      }
+
+      setCallSuccess(`Call ${response.call.id} logged with ${sample.transcript.length} transcript messages.`);
+      setSummaryStatus('idle');
+      await loadCalls({ focusId: response.call.id });
+    } catch (error) {
+      console.error(error);
+      setCallSubmitError('Unable to start the call. Check configuration and try again.');
+    } finally {
+      setCallSubmitting(false);
+    }
+  }
+
+  async function handleRunDetection() {
+    if (!selectedCall) return;
+    setDetectionLoading(true);
+    setDetectionError(null);
+    try {
+      const { detectionId, detection } = await api.runCallDetection(selectedCall.call.id);
+      const newRecord: CallDetectionRecord = {
+        id: detectionId,
+        engine: detection.engine,
+        issues: detection.issues,
+        documentation: detection.documentation,
+        revenue: detection.revenue,
+        compliance: detection.compliance,
+        narrative: detection.documentation?.narrative ?? null,
+        createdAt: new Date().toISOString(),
+      };
+      setSelectedCall((prev) =>
+        prev
+          ? {
+              ...prev,
+              detections: [newRecord, ...prev.detections],
+            }
+          : prev
+      );
+      await loadCalls({ focusId: selectedCall.call.id });
+      setActiveDetection(detection);
+    } catch (error) {
+      console.error(error);
+      setDetectionError('AI detection failed. Try again later.');
+    } finally {
+      setDetectionLoading(false);
+    }
+  }
+
+  async function handleSendSummary(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedCall) return;
+    const recipients = summaryRecipients
+      .split(',')
+      .map((email) => email.trim())
+      .filter(Boolean);
+    if (!recipients.length) {
+      setSummaryError('Add at least one recipient.');
+      return;
+    }
+    setSummaryStatus('sending');
+    setSummaryError(null);
+    try {
+      const detectionId = selectedCall.detections[0]?.id;
+      await api.sendCallSummary(selectedCall.call.id, {
+        to: recipients,
+        detectionId,
+        intro: summaryIntro || undefined,
+      });
+      setSummaryStatus('sent');
+    } catch (error) {
+      console.error(error);
+      setSummaryError('Unable to send summary email.');
+      setSummaryStatus('error');
+    }
+  }
+
+  function renderIssues() {
+    if (!detectionToDisplay?.issues?.length) {
+      return <p className="call-empty">No active issues detected.</p>;
+    }
+    return (
+      <div className="call-issues">
+        {detectionToDisplay.issues.map((issue, index) => (
+          <div key={`${issue.code}-${index}`} className="call-issue-card">
+            <div className="call-issue-card__header">
+              <span className="call-issue-card__code">{issue.code}</span>
+              <span className="call-issue-card__label">{issue.label}</span>
+            </div>
+            <div className="call-issue-card__meta">
+              <span>Severity: {issue.severity}</span>
+              <span>Urgency: {issue.urgency}</span>
+              <span>Confidence: {(issue.confidence * 100).toFixed(1)}%</span>
+            </div>
+            {issue.rationale ? <p className="call-issue-card__rationale">{issue.rationale}</p> : null}
+            {issue.evidence?.length ? (
+              <ul className="call-issue-card__evidence">
+                {issue.evidence.map((ev, evidenceIndex) => (
+                  <li key={`${issue.code}-evidence-${evidenceIndex}`}>
+                    <strong>{ev.speaker}:</strong> {ev.quote}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="calls-page">
+      <header className="calls-page__header">
+        <div>
+          <h1>Care Coordination Calls</h1>
+          <p>Launch patient outreach, capture live transcripts, and orchestrate AI detection in one workflow.</p>
+        </div>
+        <button className="btn btn--glass" type="button" onClick={() => loadCalls()} disabled={listLoading}>
+          Refresh
+        </button>
+      </header>
+
+      <section className="call-create">
+        <div className="call-create__content">
+          <h2>📞 Call Patient</h2>
+          <p>
+            Start a Twilio-powered call and log the transcript. For this demo environment we seed the transcript from curated call
+            samples.
+          </p>
+          <form className="call-create__form" onSubmit={handleCreateCall}>
+            <label>
+              Patient number
+              <input
+                type="tel"
+                value={callForm.to}
+                onChange={(event) => setCallForm((prev) => ({ ...prev, to: event.target.value }))}
+                required
+              />
+            </label>
+            <label>
+              Navigator caller ID
+              <input
+                type="tel"
+                value={callForm.from}
+                onChange={(event) => setCallForm((prev) => ({ ...prev, from: event.target.value }))}
+                required
+              />
+            </label>
+            <label>
+              Transcript sample
+              <select
+                value={callForm.sampleId}
+                onChange={(event) => setCallForm((prev) => ({ ...prev, sampleId: event.target.value }))}
+                required
+              >
+                {transcriptSamples.map((sample) => (
+                  <option key={sample.id} value={sample.id}>
+                    {sample.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button className="btn" type="submit" disabled={callSubmitting}>
+              {callSubmitting ? 'Dialing…' : 'Call Patient'}
+            </button>
+          </form>
+          {callSuccess ? <p className="call-success">{callSuccess}</p> : null}
+          {callSubmitError ? <p className="call-error">{callSubmitError}</p> : null}
+        </div>
+        <aside className="call-create__sample">
+          <h3>Sample overview</h3>
+          <p>
+            {transcriptSamples.find((sample) => sample.id === callForm.sampleId)?.summary ||
+              'Choose a transcript sample to preview the storyline.'}
+          </p>
+        </aside>
+      </section>
+
+      <section className="calls-layout">
+        <div className="calls-list">
+          <div className="calls-list__header">
+            <h2>Recent calls</h2>
+            {listError ? <span className="call-error">{listError}</span> : null}
+          </div>
+          {listLoading ? (
+            <p className="call-empty">Loading call history…</p>
+          ) : callList.length === 0 ? (
+            <p className="call-empty">No calls logged yet. Start by calling a patient above.</p>
+          ) : (
+            <ul className="call-list">
+              {callList.map((call) => (
+                <li
+                  key={call.id}
+                  className={`call-list__item${call.id === selectedCallId ? ' call-list__item--active' : ''}`}
+                  onClick={() => loadCallDetail(call.id)}
+                >
+                  <div className="call-list__primary">
+                    <span className="call-list__name">{call.memberName ?? call.memberId}</span>
+                    <span
+                      className={`call-status call-status--${call.status
+                        .toLowerCase()
+                        .replace(/[^a-z0-9]+/g, '-')}`}
+                    >
+                      {normalizeStatus(call.status)}
+                    </span>
+                  </div>
+                  <div className="call-list__meta">
+                    <span>{formatDateTime(call.startedAt)}</span>
+                    <span>{formatDuration(call.durationSeconds)}</span>
+                    <span>{call.transcriptMessageCount} msgs</span>
+                    {call.lastDetection ? <span>{call.lastDetection.issueCount} issues</span> : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="call-detail">
+          {detailLoading ? (
+            <p className="call-empty">Loading call detail…</p>
+          ) : detailError ? (
+            <p className="call-error">{detailError}</p>
+          ) : !selectedCall ? (
+            <p className="call-empty">Select a call to inspect transcript and detections.</p>
+          ) : (
+            <>
+              <div className="call-detail__header">
+                <div>
+                  <h2>{selectedCall.call.memberName ?? selectedCall.call.memberId}</h2>
+                  <p>
+                    {formatDateTime(selectedCall.call.startedAt)} · {normalizeStatus(selectedCall.call.status)} ·{' '}
+                    {formatDuration(selectedCall.call.durationSeconds)}
+                  </p>
+                </div>
+                <div className="call-detail__actions">
+                  <button className="btn btn--accent" type="button" onClick={handleRunDetection} disabled={detectionLoading}>
+                    {detectionLoading ? 'Analyzing…' : 'Run AI Detection'}
+                  </button>
+                </div>
+              </div>
+
+              {detectionError ? <p className="call-error">{detectionError}</p> : null}
+
+              <div className="call-detail__body">
+                <div className="call-transcript">
+                  <h3>Transcript</h3>
+                  {selectedCall.transcript.messages.length === 0 ? (
+                    <p className="call-empty">No transcript captured yet.</p>
+                  ) : (
+                    <ul>
+                      {selectedCall.transcript.messages.map((message, index) => (
+                        <li key={`${message.timestamp}-${index}`} className={`call-line call-line--${message.speaker}`}>
+                          <div className="call-line__meta">
+                            <span className="call-line__speaker">{message.speaker}</span>
+                            {message.timestamp ? (
+                              <span className="call-line__time">{formatDateTime(message.timestamp)}</span>
+                            ) : null}
+                          </div>
+                          <p className="call-line__text">{message.text}</p>
+                          {message.language ? (
+                            <span className="call-line__language">Language: {message.language.toUpperCase()}</span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                <div className="call-detection">
+                  <h3>AI Detection</h3>
+                  {renderIssues()}
+
+                  <div className="call-summary">
+                    <h4>Send summary email</h4>
+                    <form onSubmit={handleSendSummary} className="call-summary__form">
+                      <label>
+                        Recipients
+                        <input
+                          type="text"
+                          value={summaryRecipients}
+                          onChange={(event) => setSummaryRecipients(event.target.value)}
+                          placeholder="careteam@example.com"
+                        />
+                      </label>
+                      <label>
+                        Intro message (optional)
+                        <textarea
+                          value={summaryIntro}
+                          onChange={(event) => setSummaryIntro(event.target.value)}
+                          rows={3}
+                          placeholder="Context for the outreach team"
+                        />
+                      </label>
+                      <button className="btn btn--glass" type="submit" disabled={summaryStatus === 'sending'}>
+                        {summaryStatus === 'sending' ? 'Sending…' : 'Send summary'}
+                      </button>
+                    </form>
+                    {summaryError ? <p className="call-error">{summaryError}</p> : null}
+                    {summaryStatus === 'sent' ? (
+                      <p className="call-success">Summary email sent successfully.</p>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/pages/Member.tsx
+++ b/web/src/pages/Member.tsx
@@ -1,19 +1,6 @@
 import { useMemo, useState } from 'react';
 import { api, type DetectionResponse } from '../api';
-
-type TranscriptMessage = {
-  speaker: string;
-  text: string;
-  language?: string;
-  timestamp?: string;
-};
-
-type TranscriptSample = {
-  id: string;
-  title: string;
-  summary: string;
-  transcript: TranscriptMessage[];
-};
+import { transcriptSamples, type TranscriptMessage } from '../data/transcripts';
 
 type Suggestion = {
   code: string;
@@ -25,89 +12,6 @@ type Suggestion = {
   evidence: TranscriptMessage[];
   estimatedRevenue: number;
 };
-
-const transcriptSamples: TranscriptSample[] = [
-  {
-    id: 'alex-rivera',
-    title: 'Alex Rivera | Food + Utilities',
-    summary: 'Bilingual outreach call covering food access, SNAP renewal, and power shutoff risk.',
-    transcript: [
-      {
-        speaker: 'navigator',
-        text: 'Hola Alex, thanks for picking up. We are checking in about groceries and your SNAP renewal.',
-        language: 'es',
-        timestamp: '2025-01-17T15:03:00Z',
-      },
-      {
-        speaker: 'member',
-        text: 'Yeah it has been rough. The food bank is the only place I eat lately and sometimes they close early.',
-        language: 'en',
-        timestamp: '2025-01-17T15:03:27Z',
-      },
-      {
-        speaker: 'member',
-        text: 'Mi nevera está vacía casi siempre y me salto comidas.',
-        language: 'es',
-        timestamp: '2025-01-17T15:03:48Z',
-      },
-      {
-        speaker: 'navigator',
-        text: 'We can escalate the emergency pantry delivery. Did the utility company restore your electricity yet?',
-        language: 'en',
-        timestamp: '2025-01-17T15:04:03Z',
-      },
-      {
-        speaker: 'member',
-        text: 'No, my electricity got shut off on Tuesday and they said it might take a week unless I pay everything.',
-        language: 'en',
-        timestamp: '2025-01-17T15:04:18Z',
-      },
-      {
-        speaker: 'member',
-        text: 'Estoy durmiendo en mi coche por las noches para mantenerme caliente.',
-        language: 'es',
-        timestamp: '2025-01-17T15:04:39Z',
-      },
-      {
-        speaker: 'navigator',
-        text: 'That is not safe. We will activate utility relief and emergency housing supports right now.',
-        language: 'en',
-        timestamp: '2025-01-17T15:04:55Z',
-      },
-    ],
-  },
-  {
-    id: 'maria-lopez',
-    title: 'María López | Transportation + Meds',
-    summary: 'SMS follow-up about transportation barriers and medication affordability.',
-    transcript: [
-      {
-        speaker: 'member',
-        text: 'My landlord is evicting me next month so I am packing up.',
-        language: 'en',
-        timestamp: '2025-01-12T19:12:45Z',
-      },
-      {
-        speaker: 'member',
-        text: 'No tengo coche ahora, el motor murió y no tengo transporte para llegar a la clínica.',
-        language: 'es',
-        timestamp: '2025-01-12T19:13:10Z',
-      },
-      {
-        speaker: 'member',
-        text: "I can't afford my medications until next paycheck. Maybe in two weeks.",
-        language: 'en',
-        timestamp: '2025-01-12T19:13:54Z',
-      },
-      {
-        speaker: 'nurse',
-        text: 'Thanks María, logging this for the care team. We will set up mail-order meds and a Lyft voucher.',
-        language: 'en',
-        timestamp: '2025-01-12T19:14:11Z',
-      },
-    ],
-  },
-];
 
 export default function Member() {
   const memberId = 'demo-member';
@@ -336,6 +240,16 @@ export default function Member() {
             </button>
             <button className="btn btn--outline" onClick={exportPdf} disabled={loadingAction === 'pdf'}>
               {loadingAction === 'pdf' ? 'Exporting…' : 'Export evidence pack'}
+            </button>
+            <button
+              type="button"
+              className="btn btn--glass"
+              onClick={() => {
+                window.history.pushState({}, '', '/calls');
+                window.dispatchEvent(new PopStateEvent('popstate'));
+              }}
+            >
+              📞 Call Patient
             </button>
           </div>
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -21,6 +21,72 @@ body {
   min-height: 100vh;
 }
 
+.app-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 48px;
+  gap: 32px;
+}
+
+.app-header__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.app-header__logo {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.app-header__subtitle {
+  font-size: 0.85rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.app-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.app-nav__item {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(248, 250, 252, 0.65);
+  color: #0f172a;
+  padding: 10px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.app-nav__item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px -22px rgba(15, 23, 42, 0.4);
+}
+
+.app-nav__item--active {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #f8fafc;
+  box-shadow: 0 18px 34px -22px rgba(79, 70, 229, 0.65);
+  border-color: transparent;
+}
+
+.app-main {
+  flex: 1;
+  padding: 0 48px 72px;
+}
+
 .page-shell {
   padding: 48px 24px 72px;
   max-width: 1200px;
@@ -197,6 +263,420 @@ body {
   color: #f8fafc;
   border: 1px solid rgba(148, 163, 184, 0.5);
   box-shadow: none;
+}
+
+.call-error {
+  margin-top: 8px;
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.call-success {
+  margin-top: 8px;
+  color: #16a34a;
+  font-weight: 600;
+}
+
+.call-empty {
+  margin: 0;
+  padding: 24px;
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 18px;
+  color: #475569;
+}
+
+.calls-page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.calls-page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 28px 32px;
+  border-radius: 28px;
+  box-shadow: 0 25px 45px -28px rgba(15, 23, 42, 0.2);
+}
+
+.calls-page__header h1 {
+  margin: 0 0 6px;
+  font-size: 1.8rem;
+}
+
+.calls-page__header p {
+  margin: 0;
+  color: #475569;
+  max-width: 520px;
+  line-height: 1.5;
+}
+
+.call-create {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+  gap: 24px;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 28px;
+  padding: 32px;
+  box-shadow: 0 25px 55px -30px rgba(15, 23, 42, 0.22);
+}
+
+.call-create__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.call-create__content h2 {
+  margin: 0;
+}
+
+.call-create__content p {
+  margin: 0;
+  color: #475569;
+}
+
+.call-create__form {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.call-create__form label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.call-create__form input,
+.call-create__form select,
+.call-summary__form input,
+.call-summary__form textarea {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  background: rgba(248, 250, 252, 0.85);
+  color: #0f172a;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.call-create__form input:focus,
+.call-create__form select:focus,
+.call-summary__form input:focus,
+.call-summary__form textarea:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.call-create__sample {
+  background: rgba(30, 64, 175, 0.08);
+  border: 1px dashed rgba(37, 99, 235, 0.35);
+  border-radius: 22px;
+  padding: 24px;
+  color: #1e3a8a;
+}
+
+.call-create__sample h3 {
+  margin-top: 0;
+}
+
+.calls-layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+}
+
+.calls-list {
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 20px 45px -32px rgba(15, 23, 42, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.calls-list__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.call-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.call-list__item {
+  border-radius: 18px;
+  padding: 16px;
+  background: rgba(248, 250, 252, 0.8);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.call-list__item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.call-list__item--active {
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 15px 35px -28px rgba(99, 102, 241, 0.5);
+  background: rgba(238, 242, 255, 0.9);
+}
+
+.call-list__primary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.call-list__meta {
+  display: flex;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: #475569;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.call-status {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.call-status--completed {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.call-status--initiated,
+.call-status--ringing,
+.call-status--in-progress,
+.call-status--answered {
+  background: rgba(250, 204, 21, 0.18);
+  color: #a16207;
+}
+
+.call-status--failed,
+.call-status--canceled,
+.call-status--no-answer,
+.call-status--busy {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+}
+
+.call-detail {
+  background: rgba(255, 255, 255, 0.88);
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: 0 24px 55px -32px rgba(15, 23, 42, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.call-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.call-detail__header h2 {
+  margin: 0 0 6px;
+}
+
+.call-detail__header p {
+  margin: 0;
+  color: #475569;
+}
+
+.call-detail__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.call-detail__body {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.call-transcript,
+.call-detection {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 24px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.call-transcript ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.call-line {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 12px 28px -24px rgba(15, 23, 42, 0.25);
+  border-left: 4px solid rgba(99, 102, 241, 0.35);
+}
+
+.call-line__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #475569;
+  margin-bottom: 6px;
+}
+
+.call-line__speaker {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.call-line__text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+  line-height: 1.5;
+}
+
+.call-line__language {
+  display: inline-flex;
+  margin-top: 6px;
+  font-size: 0.75rem;
+  background: rgba(59, 130, 246, 0.15);
+  color: #1e3a8a;
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.call-issues {
+  display: grid;
+  gap: 14px;
+}
+
+.call-issue-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 20px;
+  padding: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 38px -30px rgba(15, 23, 42, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.call-issue-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: baseline;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.call-issue-card__code {
+  font-size: 0.85rem;
+  background: rgba(99, 102, 241, 0.18);
+  color: #4338ca;
+  padding: 4px 10px;
+  border-radius: 999px;
+  letter-spacing: 0.08em;
+}
+
+.call-issue-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.call-issue-card__rationale {
+  margin: 0;
+  color: #0f172a;
+}
+
+.call-issue-card__evidence {
+  margin: 0;
+  padding-left: 18px;
+  color: #1f2937;
+  font-size: 0.85rem;
+}
+
+.call-summary {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 20px;
+  padding: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.call-summary__form {
+  display: grid;
+  gap: 12px;
+}
+
+@media (max-width: 960px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app-main {
+    padding: 0 24px 56px;
+  }
+
+  .call-create {
+    grid-template-columns: 1fr;
+  }
+
+  .calls-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    padding: 24px;
+  }
+
+  .calls-page__header {
+    flex-direction: column;
+  }
 }
 
 .scenarios-shell {


### PR DESCRIPTION
## Summary
- add calls, call_transcripts, and call_detections tables plus HTTP endpoints to initiate calls, stream transcripts, run AI detection, and send summaries
- implement a Twilio voice helper and seed data to simulate a completed call transcript
- introduce a Care Calls dashboard with call initiation, transcript viewing, AI detection controls, and summary email tooling alongside new client API helpers and styling

## Testing
- npm --prefix server run build
- npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68e76afc898483318ae5706fb802b1ae